### PR TITLE
Extension attribution system（拡張解析機能）を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,7 @@ ProjectMemoryは3つのインデックスを保持：
 - `find_symbol_definition`: プロジェクト全体でシンボル定義を検索
 - `list_property_wrappers`: SwiftUI Property Wrapper解析（@State, @Binding, @ObservedObject等）
 - `list_protocol_conformances`: Protocol準拠と継承関係の解析（UITableViewDelegate, ObservableObject等）
+- `list_extensions`: Extension解析（拡張対象の型、メンバー一覧）
 
 ### コンテキスト効率的な読み取り
 - `read_function_body`: 単一関数の実装を抽出（シンプルなブレースカウント）

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 - **`find_symbol_definition`** - プロジェクト全体でシンボル定義を検索
 - **`list_property_wrappers`** - SwiftUI Property Wrapper（@State, @Binding等）を検出
 - **`list_protocol_conformances`** - Protocol準拠と継承関係を解析（UITableViewDelegate, ObservableObject等）
+- **`list_extensions`** - Extension解析（拡張対象の型、プロトコル準拠、メンバー一覧）
 
 ### 効率的な読み取り
 - **`read_function_body`** - 特定の関数実装のみを抽出

--- a/Tests/Fixtures/TestExtension.swift
+++ b/Tests/Fixtures/TestExtension.swift
@@ -1,0 +1,54 @@
+import Foundation
+import UIKit
+
+// Base class
+class ViewController: UIViewController {
+    var data: [String] = []
+}
+
+// Extension with protocol conformance
+extension ViewController: UITableViewDelegate, UITableViewDataSource {
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return data.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = UITableViewCell()
+        cell.textLabel?.text = data[indexPath.row]
+        return cell
+    }
+}
+
+// Extension without protocol (category)
+extension ViewController {
+    func setupUI() {
+        view.backgroundColor = .white
+        title = "My View"
+    }
+
+    func loadData() {
+        data = ["Item 1", "Item 2", "Item 3"]
+    }
+}
+
+// Extension on standard type
+extension String {
+    var isValidEmail: Bool {
+        return contains("@")
+    }
+
+    func trimmed() -> String {
+        return trimmingCharacters(in: .whitespaces)
+    }
+}
+
+// Extension with computed property
+extension Array where Element == Int {
+    var sum: Int {
+        return reduce(0, +)
+    }
+}


### PR DESCRIPTION
## 概要

Extension（拡張）がどの型を拡張しているか、どのプロトコルに準拠しているか、どのメンバーを持つかを解析する機能を追加しました。

## 主な変更内容

### 新規ツール: `list_extensions`
- **拡張対象の型**: どの型（Class, Struct等）を拡張しているか
- **プロトコル準拠**: Extension内で準拠しているプロトコル一覧
- **メンバー一覧**: Extension内のFunction, Variable, Initializerを列挙

### 対応するパターン
- **プロトコル準拠の分離**: `extension ViewController: UITableViewDelegate`
- **機能カテゴリ化**: `extension ViewController { /* UI setup methods */ }`
- **標準型の拡張**: `extension String { ... }`
- **ジェネリック制約付き**: `extension Array where Element == Int { ... }`

### 出力例
```
[Extension] ViewController (line 10)
  Conforms to: UITableViewDelegate, UITableViewDataSource
  Members:
    [Function] numberOfSections (line 11)
    [Function] tableView(_:numberOfRowsInSection:) (line 15)
    [Function] tableView(_:cellForRowAt:) (line 19)
```

### ドキュメント更新
- CLAUDE.md: ツール一覧に追加
- README.md: ツール一覧に追加

### テストファイル
- `Tests/Fixtures/TestExtension.swift`: 各種Extensionパターンのテストケース

## 実装詳細

SwiftSyntaxの`ExtensionDeclSyntax`を解析：
1. 拡張対象の型名を取得（`extendedType`）
2. プロトコル準拠を抽出（`inheritanceClause`）
3. メンバーブロックを走査してFunction/Variable/Initializerを収集

## 変更統計

- **1コミット**
- **4ファイル変更**
- **+186行追加**

## テスト結果

✅ 4種類のExtensionパターンで動作確認済み
- プロトコル準拠Extension
- カテゴリExtension
- 標準型Extension  
- ジェネリック制約付きExtension

✅ Extension内のメンバーが階層的に表示されることを確認
✅ MCP経由での動作確認完了

## レビュー観点

- SwiftSyntaxによるExtension解析ロジック
- メンバー抽出の網羅性（Function, Variable, Initializerなど）
- iOS開発でよく使われるExtensionパターンへの対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>