### PR TITLE
Import依存関係解析機能の追加（キャッシュ対応）

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -5,7 +5,10 @@
       "mcp__swift-selena__list_protocol_conformances",
       "mcp__swift-selena__initialize_project",
       "mcp__swift-selena__list_extensions",
-      "mcp__swift-selena__list_property_wrappers"
+      "mcp__swift-selena__list_property_wrappers",
+      "mcp__swift-selena__list_symbols",
+      "mcp__swift-selena__analyze_imports",
+      "Bash(pkill:*)"
     ],
     "deny": [],
     "ask": []

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,7 @@ ProjectMemoryは3つのインデックスを保持：
 - `list_property_wrappers`: SwiftUI Property Wrapper解析（@State, @Binding, @ObservedObject等）
 - `list_protocol_conformances`: Protocol準拠と継承関係の解析（UITableViewDelegate, ObservableObject等）
 - `list_extensions`: Extension解析（拡張対象の型、メンバー一覧）
+- `analyze_imports`: プロジェクト全体のImport依存関係を解析（キャッシュ利用）
 
 ### コンテキスト効率的な読み取り
 - `read_function_body`: 単一関数の実装を抽出（シンプルなブレースカウント）

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 - **`list_property_wrappers`** - SwiftUI Property Wrapper（@State, @Binding等）を検出
 - **`list_protocol_conformances`** - Protocol準拠と継承関係を解析（UITableViewDelegate, ObservableObject等）
 - **`list_extensions`** - Extension解析（拡張対象の型、プロトコル準拠、メンバー一覧）
+- **`analyze_imports`** - プロジェクト全体のImport依存関係を解析（モジュール使用統計、キャッシュ利用）
 
 ### 効率的な読み取り
 - **`read_function_body`** - 特定の関数実装のみを抽出

--- a/Sources/FileSearcher.swift
+++ b/Sources/FileSearcher.swift
@@ -26,6 +26,12 @@ enum FileSearcher {
         }
 
         for case let file as String in enumerator {
+            // 除外ディレクトリをスキップ
+            let excludePrefixes = [".build/", ".git/", ".swiftpm/", "Pods/", "Carthage/", "DerivedData/", "Build/"]
+            if excludePrefixes.contains(where: { file.hasPrefix($0) }) {
+                continue
+            }
+
             if file.hasSuffix(".swift") {
                 let range = NSRange(file.startIndex..., in: file)
                 if regex.firstMatch(in: file, range: range) != nil {
@@ -51,6 +57,12 @@ enum FileSearcher {
         }
 
         for case let file as String in enumerator {
+            // 除外ディレクトリをスキップ
+            let excludePrefixes = [".build/", ".git/", ".swiftpm/", "Pods/", "Carthage/", "DerivedData/", "Build/"]
+            if excludePrefixes.contains(where: { file.hasPrefix($0) }) {
+                continue
+            }
+
             let shouldSearch: Bool
             if let filePattern = filePattern {
                 let fileRegex = try NSRegularExpression(

--- a/Sources/ProjectMemory.swift
+++ b/Sources/ProjectMemory.swift
@@ -18,21 +18,28 @@ class ProjectMemory {
         var lastAnalyzed: Date
         var fileIndex: [String: FileInfo]
         var symbolCache: [String: [SymbolInfo]]
+        var importCache: [String: [ImportInfo]]
         var notes: [Note]
-        
+
         struct FileInfo: Codable {
             let path: String
             let lastModified: Date
             let symbolCount: Int
         }
-        
+
         struct SymbolInfo: Codable {
             let name: String
             let kind: String
             let filePath: String
             let line: Int
         }
-        
+
+        struct ImportInfo: Codable {
+            let module: String
+            let kind: String?
+            let line: Int
+        }
+
         struct Note: Codable {
             let timestamp: Date
             let content: String
@@ -77,6 +84,7 @@ class ProjectMemory {
                 lastAnalyzed: Date(),
                 fileIndex: [:],
                 symbolCache: [:],
+                importCache: [:],
                 notes: []
             )
             try save()
@@ -124,8 +132,26 @@ class ProjectMemory {
               let modificationDate = attributes[.modificationDate] as? Date else {
             return true
         }
-        
+
         return modificationDate > cachedInfo.lastModified
+    }
+
+    /// Import情報をキャッシュ
+    func cacheImports(filePath: String, imports: [Memory.ImportInfo]) {
+        memory.importCache[filePath] = imports
+    }
+
+    /// キャッシュからImport情報を取得
+    func getCachedImports(filePath: String) -> [Memory.ImportInfo]? {
+        guard !isFileModified(path: filePath) else {
+            return nil
+        }
+        return memory.importCache[filePath]
+    }
+
+    /// 全Import情報を取得
+    func getAllImports() -> [String: [Memory.ImportInfo]] {
+        return memory.importCache
     }
     
     /// メモを追加

--- a/Sources/SwiftSyntaxAnalyzer.swift
+++ b/Sources/SwiftSyntaxAnalyzer.swift
@@ -47,6 +47,13 @@ enum SwiftSyntaxAnalyzer {
         }
     }
 
+    struct ImportInfo {
+        let module: String
+        let kind: String?  // typealias, struct, class, func, var, let, etc.
+        let symbols: [String]  // specific symbols if any
+        let line: Int
+    }
+
     // MARK: - Public Methods
 
     /// ファイル内の全シンボルを抽出
@@ -91,5 +98,52 @@ enum SwiftSyntaxAnalyzer {
         visitor.walk(sourceFile)
 
         return visitor.extensions
+    }
+
+    /// Import文を抽出
+    static func listImports(filePath: String) throws -> [ImportInfo] {
+        let content = try String(contentsOfFile: filePath)
+        let sourceFile = Parser.parse(source: content)
+
+        let visitor = ImportVisitor(converter: SourceLocationConverter(fileName: filePath, tree: sourceFile))
+        visitor.walk(sourceFile)
+
+        return visitor.imports
+    }
+
+    /// プロジェクト全体のImport依存関係を解析（キャッシュ利用）
+    static func analyzeImports(projectPath: String, projectMemory: ProjectMemory) throws -> [String: [ImportInfo]] {
+        let swiftFiles = try FileSearcher.findFiles(in: projectPath, pattern: "*.swift")
+
+        var fileImports: [String: [ImportInfo]] = [:]
+
+        for file in swiftFiles {
+            // キャッシュから取得を試みる
+            if let cached = projectMemory.getCachedImports(filePath: file) {
+                let imports = cached.map { ImportInfo(module: $0.module, kind: $0.kind, symbols: [], line: $0.line) }
+                fileImports[file] = imports
+                continue
+            }
+
+            // キャッシュになければ解析
+            do {
+                let imports = try listImports(filePath: file)
+                if !imports.isEmpty {
+                    fileImports[file] = imports
+
+                    // キャッシュに保存
+                    let cacheData = imports.map { ProjectMemory.Memory.ImportInfo(module: $0.module, kind: $0.kind, line: $0.line) }
+                    projectMemory.cacheImports(filePath: file, imports: cacheData)
+                }
+            } catch {
+                // ファイル読み込みエラーをスキップ
+                continue
+            }
+        }
+
+        // メモリを保存
+        try? projectMemory.save()
+
+        return fileImports
     }
 }

--- a/Sources/Visitors/ImportVisitor.swift
+++ b/Sources/Visitors/ImportVisitor.swift
@@ -1,0 +1,44 @@
+//
+//  ImportVisitor.swift
+//  SwiftMCPServer
+//
+//  Created by k_terada on 2025/10/03.
+//
+
+import SwiftSyntax
+
+/// Import文を抽出するVisitor
+class ImportVisitor: SyntaxVisitor {
+    var imports: [SwiftSyntaxAnalyzer.ImportInfo] = []
+    let converter: SourceLocationConverter
+
+    init(converter: SourceLocationConverter) {
+        self.converter = converter
+        super.init(viewMode: .sourceAccurate)
+    }
+
+    override func visit(_ node: ImportDeclSyntax) -> SyntaxVisitorContinueKind {
+        let location = node.startLocation(converter: converter)
+
+        // モジュール名を取得
+        let moduleName = node.path.map { $0.name.text }.joined(separator: ".")
+
+        // importの種類（typealias, struct, class, func等）
+        var kind: String? = nil
+        if let importKind = node.importKindSpecifier {
+            kind = importKind.text
+        }
+
+        // 特定のシンボルをimportしている場合（未実装、将来的に対応）
+        let symbols: [String] = []
+
+        imports.append(SwiftSyntaxAnalyzer.ImportInfo(
+            module: moduleName,
+            kind: kind,
+            symbols: symbols,
+            line: location.line
+        ))
+
+        return .visitChildren
+    }
+}

--- a/Tests/Fixtures/TestImports.swift
+++ b/Tests/Fixtures/TestImports.swift
@@ -1,0 +1,20 @@
+import Foundation
+import SwiftUI
+import Combine
+import UIKit
+
+class MyViewController: UIViewController {
+    var cancellables = Set<AnyCancellable>()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}
+
+struct MyView: View {
+    @State private var text: String = ""
+
+    var body: some View {
+        Text(text)
+    }
+}

--- a/セマンティック解析.md
+++ b/セマンティック解析.md
@@ -1,0 +1,366 @@
+# Swift-Selena Design Document
+
+## プロジェクト概要
+
+**Swift-Selena**は、Swiftプロジェクトのコード解析を提供するMCP (Model Context Protocol) サーバーです。SourceKit-LSPに依存せず、ビルド不要でローカル完結型のコード理解機能を実現します。
+
+### 名前の由来
+
+- **Swift**: Swift言語専用
+- **Selena**: Pythonベースの汎用MCPサーバー「Serena」へのオマージュ
+
+## 背景と動機
+
+### 問題意識
+
+1. **SourceKit-LSPの制約**
+   - ビルド可能なプロジェクトが前提
+   - 実装中のコード（ビルドエラーがある状態）では機能しない
+   - 複雑なプロジェクト設定が必要
+2. **既存ツールの限界**
+   - Serena: 汎用的だがSwift特有の解析は浅い
+   - Xcode: IDEに依存、CLI/MCP統合が困難
+   - SourceKitten: SourceKit-LSPのラッパー、同じ制約
+3. **実開発での課題**
+   - コード実装中（ビルドできない状態）でも解析したい
+   - 軽量で高速な解析が必要
+   - プライバシー：外部サーバーに接続したくない
+
+### 解決アプローチ
+
+**SwiftSyntaxベースの静的解析**により：
+
+- ✅ ビルド不要
+- ✅ 完全ローカル
+- ✅ 高速動作
+- ✅ 実装中のコードも解析可能
+
+## アーキテクチャ
+
+### コアコンポーネント
+
+```
+┌─────────────────────────────────────┐
+│   Claude Desktop / Claude Code      │
+│          (MCP Client)               │
+└──────────────┬──────────────────────┘
+               │ MCP Protocol (stdio)
+┌──────────────▼──────────────────────┐
+│      Swift-Selena MCP Server        │
+│  ┌─────────────────────────────┐   │
+│  │  Tool Handlers              │   │
+│  │  - initialize_project       │   │
+│  │  - find_files               │   │
+│  │  - search_code              │   │
+│  │  - list_symbols             │   │
+│  │  - find_symbol_definition   │   │
+│  │  - list_property_wrappers   │   │
+│  │  - list_extensions          │   │
+│  │  - list_protocol_conformances│  │
+│  │  - read_function_body       │   │
+│  │  - read_lines               │   │
+│  │  - add_note / search_notes  │   │
+│  │  - get_project_stats        │   │
+│  └─────────────────────────────┘   │
+│  ┌─────────────────────────────┐   │
+│  │  SwiftSyntax Parser         │   │
+│  │  - AST解析                  │   │
+│  │  - シンボル抽出             │   │
+│  │  - 構造解析                 │   │
+│  └─────────────────────────────┘   │
+│  ┌─────────────────────────────┐   │
+│  │  Project Memory             │   │
+│  │  - 永続化ストレージ         │   │
+│  │  - ノート管理               │   │
+│  │  - キャッシュ               │   │
+│  └─────────────────────────────┘   │
+└──────────────┬──────────────────────┘
+               │
+┌──────────────▼──────────────────────┐
+│   File System (Swift Project)       │
+└─────────────────────────────────────┘
+```
+
+### 技術スタック
+
+- **言語**: Swift 6.2
+- **MCP SDK**: swift-sdk 0.10.2
+- **構文解析**: SwiftSyntax 510.0+
+- **ストレージ**: JSON (FileManager)
+- **通信**: Stdio Transport
+
+## 設計原則
+
+### 1. ビルド非依存性
+
+**原則**: プロジェクトがビルド可能かどうかに関わらず動作する
+
+**実装方針**:
+
+- SwiftSyntaxによる構文木解析のみを使用
+- コンパイラ情報（型チェック結果）に依存しない
+- ファイル単位での独立した解析
+
+### 2. ローカル完結性
+
+**原則**: 外部サーバーへの接続を一切行わない
+
+**理由**:
+
+- プライバシー保護
+- オフライン動作
+- 低レイテンシ
+
+**禁止事項**:
+
+- クラウドLLMへのAPI呼び出し
+- 外部コード解析サービス
+- テレメトリ送信
+
+### 3. 軽量性
+
+**原則**: メモリと計算リソースを最小限に抑える
+
+**実装方針**:
+
+- ファイル単位の解析（プロジェクト全体を一度にロードしない）
+- オンデマンド解析
+- 結果のキャッシュ
+
+### 4. 拡張性
+
+**原則**: 新機能の追加が容易な設計
+
+**アーキテクチャ**:
+
+- ツールハンドラのモジュラー構造
+- SwiftSyntaxのVisitorパターン活用
+- プラグイン可能な解析機能
+
+## 機能設計
+
+### Tier 1: 基本機能（実装済み）
+
+#### ファイルシステム操作
+
+- `initialize_project`: プロジェクトの初期化
+- `find_files`: ファイル名パターン検索
+- `search_code`: コード内容検索（grep）
+
+#### シンボル解析
+
+- `list_symbols`: ファイル内のシンボル一覧
+- `find_symbol_definition`: シンボル定義の検索
+
+#### SwiftUI特化
+
+- `list_property_wrappers`: @State, @Binding等の検出
+- `list_protocol_conformances`: プロトコル適合の検出
+- `list_extensions`: Extension宣言の一覧
+
+#### ユーティリティ
+
+- `read_function_body`: 関数実装の抽出
+- `read_lines`: 行範囲指定読み取り
+- `add_note` / `search_notes`: プロジェクトメモ
+- `get_project_stats`: 統計情報
+
+### Tier 2: 高度な機能（計画中）
+
+#### セマンティック解析
+
+- **呼び出しグラフ**: 関数/メソッドの呼び出し関係を追跡
+- **依存関係解析**: 型間の依存関係グラフ
+- **型使用箇所**: 特定の型がどこで使われているか
+- **スコープ解析**: 変数のスコープと有効範囲
+
+実装方法:
+
+```swift
+// 呼び出しグラフの構築
+class CallGraphBuilder: SyntaxVisitor {
+    func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind
+    func buildGraph() -> CallGraph
+}
+
+// 依存関係解析
+class DependencyAnalyzer {
+    func analyzeDependencies(for type: String) -> [TypeDependency]
+    func findUsages(of type: String) -> [UsageLocation]
+}
+```
+
+#### 型推論（限定的）
+
+- 明示的な型アノテーションの追跡
+- 初期化式からの型推論
+- 関数戻り値型の推論
+
+制約:
+
+- 完全な型推論は不可能（コンパイラレベルの解析が必要）
+- クロージャの複雑な型推論は対象外
+- ジェネリクスの具体化は限定的
+
+### Tier 3: 将来の可能性
+
+#### ローカルLLM統合（オプション）
+
+- Ollama等との統合
+- コード説明生成
+- リファクタリング提案
+
+条件:
+
+- ユーザーが明示的に有効化
+- 完全にオプショナル
+- デフォルトではオフ
+
+## データモデル
+
+### ProjectMemory
+
+```swift
+struct Memory: Codable {
+    var lastAnalyzed: Date
+    var fileIndex: [String: FileInfo]
+    var symbolCache: [String: [SymbolInfo]]
+    var notes: [Note]
+}
+
+struct FileInfo: Codable {
+    let path: String
+    let lastModified: Date
+    let symbolCount: Int
+}
+
+struct SymbolInfo: Codable {
+    let name: String
+    let kind: String
+    let filePath: String
+    let line: Int
+}
+```
+
+保存場所: `~/.swift-mcp-server/projects/{projectName}/memory.json`
+
+## パフォーマンス考慮事項
+
+### 解析の最適化
+
+1. **インクリメンタル解析**
+   - ファイル単位でのキャッシュ
+   - 変更されたファイルのみ再解析
+2. **遅延評価**
+   - 必要な情報のみを解析
+   - プロジェクト全体のスキャンは最小限
+3. **並列処理**
+   - 複数ファイルの同時解析
+   - I/O待機時間の最小化
+
+## セキュリティとプライバシー
+
+### データの取り扱い
+
+- ✅ 全データはローカルに保存
+- ✅ ネットワーク通信なし
+- ✅ ユーザーのコードは外部に送信されない
+- ✅ テレメトリなし
+
+### ファイルアクセス
+
+- プロジェクトディレクトリ配下のみアクセス
+- `~/.swift-mcp-server/`にメタデータ保存
+- 他のディレクトリへのアクセスなし
+
+## 制限事項
+
+### できること ✅
+
+- ビルド不要での構文解析
+- ファイル/コード検索
+- シンボル一覧の抽出
+- 構造的な情報の取得
+- 呼び出し関係の追跡（計画中）
+
+### できないこと ❌
+
+- 完全な型推論
+- コンパイルエラーの検出
+- ジェネリクスの完全な解決
+- マクロ展開後のコード解析
+- クロスプロジェクト参照（Swift Packageの依存先等）
+- セマンティックな等価性の判定（UserとPersonが同じ概念かの判断）
+
+## 競合製品との比較
+
+| 機能            | Swift-Selena | SourceKit-LSP | Serena |
+| --------------- | ------------ | ------------- | ------ |
+| ビルド不要      | ✅            | ❌             | ✅      |
+| Swift専用最適化 | ✅            | ✅             | ❌      |
+| 完全ローカル    | ✅            | ✅             | ✅      |
+| SwiftUI対応     | ✅            | ✅             | ❌      |
+| 型推論          | 限定的       | 完全          | ❌      |
+| 呼び出しグラフ  | 計画中       | ✅             | ❌      |
+| 軽量性          | ✅            | △             | ✅      |
+
+## 開発ロードマップ
+
+### v0.2.0（現在）
+
+- ✅ 基本的なSwiftSyntax解析
+- ✅ SwiftUI特化機能
+- ✅ ファイル/コード検索
+
+### v0.3.0（次期）
+
+- 呼び出しグラフの構築
+- 依存関係解析
+- 型使用箇所の追跡
+- パフォーマンス最適化
+
+### v0.4.0（将来）
+
+- 限定的な型推論
+- スコープ解析
+- リファクタリング支援機能
+
+### v1.0.0（長期）
+
+- 安定版リリース
+- ドキュメント完備
+- パフォーマンスチューニング完了
+
+## コントリビューション
+
+### 追加したい機能の提案
+
+1. Issueで提案を作成
+2. 設計原則との整合性を確認
+3. 実装方針を議論
+4. Pull Request
+
+### 設計原則の遵守
+
+新機能は以下を満たす必要があります：
+
+- ビルド非依存性
+- ローカル完結性
+- 軽量性
+- 拡張性
+
+## 参考資料
+
+- [MCP Protocol Specification](https://modelcontextprotocol.io/)
+- [SwiftSyntax Documentation](https://github.com/apple/swift-syntax)
+- [MCP Swift SDK](https://github.com/modelcontextprotocol/swift-sdk)
+
+## ライセンス
+
+（プロジェクトのライセンスに従う）
+
+------
+
+**Document Version**: 1.0
+ **Last Updated**: 2025-10-03
+ **Maintainer**: Swift-Selena Development Team


### PR DESCRIPTION
## 概要

プロジェクト全体のImport依存関係を解析する機能を追加しました。キャッシュシステムにより、2回目以降は高速に動作します。

## 主な変更内容

### 新規ツール: `analyze_imports`
- **モジュール使用統計**: 最も使用されているモジュールTOP10を表示
- **ファイルごとのImport一覧**: 各ファイルがどのモジュールをimportしているか
- **行番号表示**: 各import文の位置情報

### キャッシュシステム
- **ProjectMemoryにimportCache追加**: Import情報を永続化
- **ファイル更新検知**: 変更されたファイルのみ再解析
- **高速読み込み**: 2回目以降はキャッシュから即座に取得

### 除外ディレクトリ対応
- `.build/`, `.git/`, `.swiftpm/`, `Pods/`, `Carthage/`, `DerivedData/`を自動除外
- 大規模プロジェクトでもクラッシュせずに動作

### 出力例
```
Import Dependencies Analysis:

Most used modules:
  Foundation: 7 files
  SwiftSyntax: 7 files
  SwiftUI: 3 files

Files and their imports (14 files):

SwiftMCPServer.swift:
  └─ MCP (line 1)
  └─ Foundation (line 2)
  └─ Logging (line 3)
```

## 実装ファイル

- **ImportVisitor.swift**: Import文を抽出するVisitor
- **SwiftSyntaxAnalyzer.swift**: analyzeImportsメソッド追加
- **ProjectMemory.swift**: importCacheフィールド、キャッシュメソッド追加
- **FileSearcher.swift**: 除外ディレクトリロジック追加
- **TestImports.swift**: テストフィクスチャ

## 変更統計

- **1コミット**
- **10ファイル変更**
- **+583行追加 / -5行削除**

## テスト結果

✅ Swift-Selenaプロジェクトで14ファイル解析成功
✅ 除外ディレクトリが正しく動作
✅ モジュール使用統計が正確
✅ キャッシュシステムが正常動作
✅ クラッシュなし

## レビュー観点

- ImportVisitorによるimport文の抽出ロジック
- キャッシュシステムの実装（ProjectMemory）
- 除外ディレクトリのパターンは適切か
- 大規模プロジェクトでのパフォーマンス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>