### PR TITLE
XCTestケース検出機能の追加

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -17,7 +17,8 @@
       "mcp__swift-selena__read_lines",
       "mcp__swift-selena__add_note",
       "mcp__swift-selena__search_notes",
-      "mcp__swift-selena__get_project_stats"
+      "mcp__swift-selena__get_project_stats",
+      "mcp__swift-selena__find_test_cases"
     ],
     "deny": [],
     "ask": []

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,7 @@ ProjectMemoryは3つのインデックスを保持：
 - `list_extensions`: Extension解析（拡張対象の型、メンバー一覧）
 - `analyze_imports`: プロジェクト全体のImport依存関係を解析（キャッシュ利用）
 - `get_type_hierarchy`: 型の継承階層を取得（スーパークラス、サブクラス、Protocol準拠型、キャッシュ利用）
+- `find_test_cases`: XCTestケースとテストメソッドを検出
 
 ### コンテキスト効率的な読み取り
 - `read_function_body`: 単一関数の実装を抽出（シンプルなブレースカウント）

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 - **`list_extensions`** - Extension解析（拡張対象の型、プロトコル準拠、メンバー一覧）
 - **`analyze_imports`** - プロジェクト全体のImport依存関係を解析（モジュール使用統計、キャッシュ利用）
 - **`get_type_hierarchy`** - 型の継承階層を取得（スーパークラス、サブクラス、Protocol準拠型、キャッシュ利用）
+- **`find_test_cases`** - XCTestケースとテストメソッドを検出
 
 ### 効率的な読み取り
 - **`read_function_body`** - 特定の関数実装のみを抽出

--- a/Sources/Visitors/XCTestVisitor.swift
+++ b/Sources/Visitors/XCTestVisitor.swift
@@ -1,0 +1,57 @@
+//
+//  XCTestVisitor.swift
+//  SwiftMCPServer
+//
+//  Created by k_terada on 2025/10/03.
+//
+
+import SwiftSyntax
+
+/// XCTestCaseクラスとテストメソッドを抽出するVisitor
+class XCTestVisitor: SyntaxVisitor {
+    var testClasses: [SwiftSyntaxAnalyzer.XCTestInfo] = []
+    let converter: SourceLocationConverter
+    let filePath: String
+
+    init(converter: SourceLocationConverter, filePath: String) {
+        self.converter = converter
+        self.filePath = filePath
+        super.init(viewMode: .sourceAccurate)
+    }
+
+    override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+        // XCTestCaseを継承しているクラスを検出
+        let inheritsXCTestCase = node.inheritanceClause?.inheritedTypes.contains { inherited in
+            inherited.type.trimmedDescription.contains("XCTestCase")
+        } ?? false
+
+        if inheritsXCTestCase {
+            let location = node.startLocation(converter: converter)
+            var testMethods: [SwiftSyntaxAnalyzer.XCTestInfo.TestMethod] = []
+
+            // クラス内のテストメソッドを検出
+            for member in node.memberBlock.members {
+                if let funcDecl = member.decl.as(FunctionDeclSyntax.self) {
+                    let funcName = funcDecl.name.text
+                    // "test"で始まるメソッドを検出
+                    if funcName.hasPrefix("test") && !funcName.hasPrefix("testPerformance") {
+                        let funcLocation = funcDecl.startLocation(converter: converter)
+                        testMethods.append(SwiftSyntaxAnalyzer.XCTestInfo.TestMethod(
+                            name: funcName,
+                            line: funcLocation.line
+                        ))
+                    }
+                }
+            }
+
+            testClasses.append(SwiftSyntaxAnalyzer.XCTestInfo(
+                className: node.name.text,
+                filePath: filePath,
+                line: location.line,
+                testMethods: testMethods
+            ))
+        }
+
+        return .visitChildren
+    }
+}

--- a/Tests/Fixtures/TestXCTest.swift
+++ b/Tests/Fixtures/TestXCTest.swift
@@ -1,0 +1,37 @@
+import XCTest
+
+class UserViewModelTests: XCTestCase {
+    var viewModel: UserViewModel!
+
+    override func setUp() {
+        super.setUp()
+        viewModel = UserViewModel()
+    }
+
+    func testInitialState() {
+        XCTAssertEqual(viewModel.username, "")
+        XCTAssertEqual(viewModel.email, "")
+    }
+
+    func testUpdateUsername() {
+        viewModel.username = "John"
+        XCTAssertEqual(viewModel.username, "John")
+    }
+
+    func testValidation() {
+        XCTAssertFalse(viewModel.isValid)
+        viewModel.username = "John"
+        viewModel.email = "john@example.com"
+        XCTAssertTrue(viewModel.isValid)
+    }
+}
+
+class NetworkManagerTests: XCTestCase {
+    func testFetchData() {
+        // Test implementation
+    }
+
+    func testErrorHandling() {
+        // Test implementation
+    }
+}


### PR DESCRIPTION
## 概要

XCTestケースとテストメソッドを自動検出する機能を追加しました。これでSwift-Selenaの全計画機能が完成しました。

## 主な変更内容

### 新規ツール: `find_test_cases`
- **XCTestCase継承クラス検出**: XCTestCaseを継承するテストクラスを自動検出
- **テストメソッド検出**: `test`で始まるメソッドを列挙
- **位置情報**: 各テストクラスとメソッドの行番号を表示
- **プロジェクト全体スキャン**: 全テストファイルを一括解析

### 出力例
```
XCTest Cases (2 classes):

[TestClass] UserViewModelTests
  File: TestXCTest.swift:3
  Test methods (3):
    └─ testInitialState (line 11)
    └─ testUpdateUsername (line 16)
    └─ testValidation (line 21)

[TestClass] NetworkManagerTests
  File: TestXCTest.swift:29
  Test methods (2):
    └─ testFetchData (line 30)
    └─ testErrorHandling (line 34)
```

## 実装ファイル

- **XCTestVisitor.swift**: XCTestCaseとテストメソッドを検出するVisitor
- **SwiftSyntaxAnalyzer.swift**: findTestCasesメソッド追加
- **SwiftMCPServer.swift**: find_test_casesツール追加
- **TestXCTest.swift**: テストフィクスチャ（2クラス、5メソッド）

## ユースケース

- **テストカバレッジ確認**: どのテストケースが存在するか一覧表示
- **テスト整理**: テストメソッドの分布を把握
- **リファクタリング支援**: テストクラスとメソッドの位置を素早く把握

## 変更統計

- **1コミット**
- **7ファイル変更**
- **+177行追加 / -1行削除**

## テスト結果

✅ 2つのXCTestCaseクラス検出成功
✅ 5つのテストメソッド検出成功
✅ 行番号が正確
✅ クラッシュなし
✅ 全16ツールが連続動作確認済み

## 完成機能一覧（全7機能）

これで当初計画していた全機能が完成しました：

1. ✅ Property Wrapper解析
2. ✅ Protocol Conformance検出
3. ✅ Extension attribution system
4. ✅ Import dependency mapping
5. ✅ Type inheritance graph
6. ✅ XCTest case detection
7. ✅ コードベースのリファクタリング

## レビュー観点

- XCTestVisitorの実装ロジック
- `test`で始まるメソッドの検出パターン
- テストメソッドの抽出が正確か

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>