### PR TITLE
v0.4.2: スクリプト改善と接続方法の統一

### DIFF
--- a/Sources/Constants.swift
+++ b/Sources/Constants.swift
@@ -10,7 +10,7 @@ import Foundation
 /// アプリケーション全体の定数
 enum AppConstants {
     static let name = "Swift-Selena"
-    static let version = "0.4.1"
+    static let version = "0.4.2"
     static let loggerLabel = "swift-selena"
     static let storageDirectory = ".swift-selena"
 }


### PR DESCRIPTION
## 概要

register-selena-to-claude-code.shを`claude mcp add`を使うように改善し、makefile連携も追加しました。

## 主な変更内容

### 1. スクリプトの改善
- **register-selena-to-claude-code.sh**: `claude mcp add`を使用するように変更
  - `pushd/popd`でターゲットプロジェクトに移動
  - `claude mcp add swift-selena -- <path>`で登録
  - `.claude/mcp_config.json`の手動作成を廃止
  - Claude Codeの標準的な方法で登録

### 2. makefile統合
- **TemplateApp_Moons/makefile**に以下を追加:
  - `make connect_swift-selena`: Swift-Selenaを接続
  - `make disconnect_swift-selena`: Swift-Selenaを切断
  - 環境変数`SWIFT_SELENA_PATH`でパス指定

### 3. バージョン更新
- **v0.4.2**: Constants.swiftで管理

## 使用方法

### スクリプト直接実行
```bash
cd ~/Swift-Selena
./register-selena-to-claude-code.sh ~/projects/MyApp
```

### makefile経由（推奨）
```bash
export SWIFT_SELENA_PATH=~/Swift-Selena
cd ~/projects/MyApp
make connect_swift-selena
```

## 技術的改善

- **標準化**: Claude CLIの正式な方法を使用
- **シンプル化**: 手動設定ファイル作成を廃止
- **信頼性向上**: `claude mcp add`の動作に任せる
- **保守性向上**: jqへの依存を削除

## 変更統計

- **2コミット**
- **2ファイル変更**
- **+27行追加 / -62行削除**

## テスト

手動でスクリプトをテストしてください：
```bash
./register-selena-to-claude-code.sh <your-project>
```

## レビュー観点

- `claude mcp add`の使用方法が正しいか
- `pushd/popd`の使用が適切か
- makefileとの連携が機能するか

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>