### PR TITLE
fix: README MCP接続周りの記述を修正

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -93,15 +93,37 @@ pwd
 - `claude_desktop_config.json`に設定を追加
 - 既存の設定を保持（jqがインストールされている場合）
 
-#### Claude Codeの場合
+#### Claude Codeの場合（特定プロジェクトに接続）
+
+Swift-Selenaを特定のプロジェクトに接続するには：
+
 ```bash
-./register-mcp-to-claude-code.sh
+# Swift-Selenaディレクトリから実行
+./register-selena-to-claude-code.sh /path/to/your/project
 ```
 
 このスクリプトは以下を自動実行します：
 - 実行ファイルの存在確認
-- claude CLIへの登録（`claude mcp add`）
-- 既存登録の上書き確認
+- ターゲットプロジェクトディレクトリに移動
+- `claude mcp add`で登録（そのプロジェクトのみ有効）
+
+**別の方法：makefileを使用**（プロジェクトにmakefileがある場合）
+
+プロジェクトのmakefileに追加：
+```make
+connect_swift-selena:
+	@if [ -n "$$SWIFT_SELENA_PATH" ]; then \
+		claude mcp add swift-selena -- $$SWIFT_SELENA_PATH/.build/release/Swift-Selena; \
+	else \
+		echo "SWIFT_SELENA_PATHを設定してください"; \
+	fi
+```
+
+使用方法：
+```bash
+export SWIFT_SELENA_PATH=/path/to/Swift-Selena
+make connect_swift-selena
+```
 
 ### 手動セットアップ
 
@@ -133,28 +155,24 @@ open ~/Library/Application\ Support/Claude/claude_desktop_config.json
 
 3. Claude Desktopを再起動
 
-### Claude Code の設定
+#### Claude Code 手動設定
 
-Claude Codeでは`MCP_CLIENT_ID`の設定は不要です（デフォルトで`default`が使用されます）。
+ターゲットプロジェクトのディレクトリで：
 
-MCPサーバーの設定方法は[Claude Codeドキュメント](https://docs.claude.com/claude-code)を参照してください。
-
-**複数のClaude Codeで同じプロジェクトを開く場合**: `mcp_config.json`に以下のように`MCP_CLIENT_ID`を設定してください。
-
-```json
-{
-  "mcpServers": {
-    "swift-selena": {
-      "command": "/path/to/Swift-Selena/.build/release/Swift-Selena",
-      "env": {
-        "MCP_CLIENT_ID": "claude-code-window1"
-      }
-    }
-  }
-}
+```bash
+cd /path/to/your/project
+claude mcp add swift-selena -- /path/to/Swift-Selena/.build/release/Swift-Selena
 ```
 
-別のウィンドウでは`claude-code-window2`など、異なるIDを使用してください。
+これでそのプロジェクトのみで有効なローカル設定が作成されます。
+
+**グローバルに使用する場合**（全プロジェクトで有効）：
+```bash
+cd ~
+claude mcp add -s user swift-selena -- /path/to/Swift-Selena/.build/release/Swift-Selena
+```
+
+詳細は[Claude Codeドキュメント](https://docs.claude.com/claude-code)を参照してください。
 
 ## 使い方
 

--- a/README.md
+++ b/README.md
@@ -93,15 +93,37 @@ This script automatically:
 - Adds settings to `claude_desktop_config.json`
 - Preserves existing settings (if jq is installed)
 
-#### For Claude Code
+#### For Claude Code (Connect to Specific Project)
+
+To connect Swift-Selena to a specific project:
+
 ```bash
-./register-mcp-to-claude-code.sh
+# From Swift-Selena directory
+./register-selena-to-claude-code.sh /path/to/your/project
 ```
 
 This script automatically:
 - Verifies executable existence
-- Registers with claude CLI (`claude mcp add`)
-- Confirms overwrite of existing registration
+- Moves to target project directory
+- Registers with `claude mcp add` (local to that project)
+
+**Alternative: Using makefile** (if your project has one)
+
+Add to your project's makefile:
+```make
+connect_swift-selena:
+	@if [ -n "$$SWIFT_SELENA_PATH" ]; then \
+		claude mcp add swift-selena -- $$SWIFT_SELENA_PATH/.build/release/Swift-Selena; \
+	else \
+		echo "Set SWIFT_SELENA_PATH first"; \
+	fi
+```
+
+Then:
+```bash
+export SWIFT_SELENA_PATH=/path/to/Swift-Selena
+make connect_swift-selena
+```
 
 ### Manual Setup
 
@@ -133,28 +155,24 @@ open ~/Library/Application\ Support/Claude/claude_desktop_config.json
 
 3. Restart Claude Desktop
 
-#### Claude Code Setup
+#### Claude Code Manual Setup
 
-Claude Code uses `default` as the `MCP_CLIENT_ID` by default (no configuration needed).
+In your target project directory:
 
-Refer to [Claude Code documentation](https://docs.claude.com/claude-code) for MCP server configuration.
-
-**For multiple Claude Code windows on the same project**: Configure `MCP_CLIENT_ID` in `mcp_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "swift-selena": {
-      "command": "/path/to/Swift-Selena/.build/release/Swift-Selena",
-      "env": {
-        "MCP_CLIENT_ID": "claude-code-window1"
-      }
-    }
-  }
-}
+```bash
+cd /path/to/your/project
+claude mcp add swift-selena -- /path/to/Swift-Selena/.build/release/Swift-Selena
 ```
 
-Use different IDs like `claude-code-window2` for other windows.
+This creates a local configuration for that project only.
+
+**To use globally** (all projects):
+```bash
+cd ~
+claude mcp add -s user swift-selena -- /path/to/Swift-Selena/.build/release/Swift-Selena
+```
+
+Refer to [Claude Code documentation](https://docs.claude.com/claude-code) for more MCP server configuration options.
 
 ## Usage
 


### PR DESCRIPTION
## 概要

README.mdとREADME.ja.mdのMCP接続周りの記述を最新の仕様に合わせて修正しました。

## 主な変更内容

### Claude Code設定セクションの修正

#### Before（問題点）
- 古いスクリプト名（`register-mcp-to-claude-code.sh`、削除済み）
- 不正確な設定ファイル説明（`.claude/mcp_config.json`、非標準）
- 設定方法が不明確

#### After（改善）
- **正しいスクリプト名**: `register-selena-to-claude-code.sh`
- **スクリプトの動作を正確に記載**:
  - ターゲットプロジェクトに移動
  - `claude mcp add`で登録
  - プロジェクトローカル設定
- **makefile連携の方法を追加**
- **手動設定を更新**:
  - `claude mcp add`コマンドの使い方
  - ローカル設定 vs グローバル設定（`-s user`）の説明

### 両言語版で統一

- README.md（英語版）
- README.ja.md（日本語版）

両方とも同じ内容に更新

## 変更統計

- **1コミット**
- **2ファイル変更**
- **+76行追加 / -40行削除**

## レビュー観点

- MCP接続方法の説明が正確か
- ユーザーが迷わず設定できるか
- 両言語版で内容が一致しているか

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>