### PR TITLE
feat: unify search_files_without_pattern API to include/exclude_patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ Swift-Selenaのリリース履歴
 
 ---
 
+## v0.6.9 - 2026-05-17
+
+### Issue #34: `search_files_without_pattern` のパラメータ API 統一
+
+- **breaking**: `search_files_without_pattern` の `file_pattern` パラメータを廃止
+  - `include_patterns` / `exclude_patterns`（glob 配列、各最大 20 件）へ統一し、`search_code` と API を揃えた
+  - 未知パラメータとして `file_pattern` が渡された場合は DES-104 §5.1 に従い無視（エラーにはしない）
+- **feat**: `FileSearcher.searchFilesWithoutPattern` を `includePatterns` / `excludePatterns` 引数に刷新
+  - `searchCode` と共通の `shouldSearchFile` / `compiledGlobRegexes` ヘルパを再利用し、include OR / exclude 優先の評価規則を統一
+- **feat**: `SearchFilesWithoutPatternTool` で正規表現構文・glob 構文・配列要素数を Tool 層で事前検証
+  - エラーは `ResultEncoder.buildErrorResponse(cause:suggestion:)` による DES-104 §8.1 統一形式で返却
+- **chore**: `Sources/Constants.swift` から `ParameterKeys.filePattern` 共有定数を完全削除
+- **test**: `BackwardCompatibilityTests` に `search_files_without_pattern` 用の 5 ケースを追加
+  - `file_pattern` 無視（破壊的変更の確認）
+  - `include_patterns` による絞り込み
+  - `exclude_patterns` の優先適用
+  - 配列要素数上限超過のエラー応答
+  - 不正な正規表現のエラー応答
+- **docs**: DES-104 を v2.1 に更新（issue #34 対応反映、両ツールへの §5.1 適用を明記）
+
+---
+
 ## v0.6.8 - 2026-05-16
 
 ### REQ-005 / DES-104: 検索・シンボルツール拡張

--- a/Sources/Constants.swift
+++ b/Sources/Constants.swift
@@ -80,11 +80,6 @@ enum ParameterKeys {
     static let projectPath = "project_path"
     static let filePath = "file_path"
     static let pattern = "pattern"
-    /// 旧 `file_pattern` パラメータキー（DES-104 §5.1 にて廃止対象）
-    /// - Note: SearchCodeTool 側からの参照は本 Feature で削除する。
-    ///   本定数自体の削除は他ツール（SearchFilesWithoutPattern 等）の修正完了を
-    ///   待つ必要があるため、issue #34 連動とし本タスクのスコープ外とする。
-    static let filePattern = "file_pattern"
     static let symbolName = "symbol_name"
     static let typeName = "type_name"
     /// search_code の出力モード（"match_detail" / "file_list" / "count_only"）

--- a/Sources/Selena/Core/FileSearcher.swift
+++ b/Sources/Selena/Core/FileSearcher.swift
@@ -245,11 +245,19 @@ enum FileSearcher {
         }
     }
 
-    /// パターンにマッチしないファイルを検索（grep -L相当）
+    /// パターンにマッチしないファイルを検索（grep -L 相当・include/exclude glob 対応）
+    ///
+    /// - Parameters:
+    ///   - directory: 走査開始ディレクトリ
+    ///   - pattern: マッチ判定に用いる正規表現（マルチラインモード）
+    ///   - includePatterns: 走査対象を絞り込む glob 配列（OR 結合）。空のときは `.swift` のみが対象
+    ///   - excludePatterns: 走査から除外する glob 配列（OR 結合、include より優先）
+    /// - Note: 評価規則は `searchCode` と共通の `shouldSearchFile` を使用する
     static func searchFilesWithoutPattern(
         in directory: String,
         pattern: String,
-        filePattern: String?
+        includePatterns: [String],
+        excludePatterns: [String]
     ) throws -> (filesWithoutPattern: [String], totalChecked: Int) {
         var filesWithoutPattern: [String] = []
         var totalChecked = 0
@@ -257,6 +265,20 @@ enum FileSearcher {
 
         // マルチラインモード（^と$が各行の先頭・末尾にマッチ）
         let regex = try NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines])
+
+        let includeRegexes: [NSRegularExpression]
+        if includePatterns.isEmpty {
+            includeRegexes = []
+        } else {
+            includeRegexes = try compiledGlobRegexes(patterns: includePatterns)
+        }
+
+        let excludeRegexes: [NSRegularExpression]
+        if excludePatterns.isEmpty {
+            excludeRegexes = []
+        } else {
+            excludeRegexes = try compiledGlobRegexes(patterns: excludePatterns)
+        }
 
         let enumerator = try directoryEnumerator(at: directory, fileManager: fileManager)
 
@@ -267,29 +289,25 @@ enum FileSearcher {
                 continue
             }
 
-            let shouldSearch: Bool
-            if let filePattern {
-                let fileRegex = try NSRegularExpression(
-                    pattern: wildcardToRegex(filePattern),
-                    options: [.caseInsensitive]
-                )
-                let range = NSRange(file.startIndex..., in: file)
-                shouldSearch = fileRegex.firstMatch(in: file, range: range) != nil
-            } else {
-                shouldSearch = file.hasSuffix(".swift")
+            guard shouldSearchFile(
+                relativePath: file,
+                includePatterns: includePatterns,
+                excludePatterns: excludePatterns,
+                includeRegexes: includeRegexes,
+                excludeRegexes: excludeRegexes
+            ) else {
+                continue
             }
 
-            if shouldSearch {
-                totalChecked += 1
-                // ファイル全体を読み込んでパターンマッチング
-                if let content = try? String(contentsOfFile: fullPath) {
-                    let range = NSRange(content.startIndex..., in: content)
-                    let hasMatch = regex.firstMatch(in: content, range: range) != nil
+            totalChecked += 1
+            // ファイル全体を読み込んでパターンマッチング
+            if let content = try? String(contentsOfFile: fullPath) {
+                let range = NSRange(content.startIndex..., in: content)
+                let hasMatch = regex.firstMatch(in: content, range: range) != nil
 
-                    // マッチしないファイルを収集
-                    if !hasMatch {
-                        filesWithoutPattern.append(fullPath)
-                    }
+                // マッチしないファイルを収集
+                if !hasMatch {
+                    filesWithoutPattern.append(fullPath)
                 }
             }
         }

--- a/Sources/Tools/FileSystem/SearchFilesWithoutPatternTool.swift
+++ b/Sources/Tools/FileSystem/SearchFilesWithoutPatternTool.swift
@@ -2,39 +2,51 @@
 //  SearchFilesWithoutPatternTool.swift
 //  Swift-Selena
 //
-//  Created on 2025/10/27.
+//  Created by k2moons on 2025/10/27.
+//
+//  [Code Header Format]
+//
+//  目的
+//  - 正規表現にマッチしないファイル一覧を MCP ツールとして提供する（grep -L 相当）
+//  - DES-104 §5.1 に従い `file_pattern` を廃止し `include_patterns` / `exclude_patterns` で対象を絞り込む
+//  - search_code とパラメータ仕様を揃え、Tool 層で入力検証してから FileSearcher へ委譲する
+//
+//  主要機能
+//  - pattern / include_patterns / exclude_patterns の取得と入力検証（DES-104 §5.3）
+//  - 廃止パラメータ file_pattern はスキーマから除外し、指定されても無視する（§5.1）
+//  - 評価規則は search_code と共通の shouldSearchFile を再利用（include OR、exclude 優先）
 //
 
 import Foundation
 import MCP
 import Logging
 
-/// パターンにマッチしないファイルを検索するツール（grep -L相当）
+/// パターンにマッチしないファイルを検索するツール（grep -L 相当）
 ///
 /// ## 目的
 /// 正規表現パターンにマッチ**しない**ファイルを検索
 ///
 /// ## 効果
-/// - Code Header未作成ファイルの一括検出
-/// - Import未記述ファイルの発見
+/// - Code Header 未作成ファイルの一括検出
+/// - Import 未記述ファイルの発見
 /// - ドキュメント整備状況の確認
 /// - 品質チェック・コンプライアンス確認
 ///
 /// ## 処理内容
-/// - プロジェクト内の全ファイルを走査（オプションでfilePatternで絞り込み）
+/// - プロジェクト内の対象ファイルを走査（include_patterns / exclude_patterns で絞り込み）
 /// - 各ファイルの全内容を読み込み
 /// - 正規表現パターンにマッチ**しない**ファイルを収集
 /// - ファイルパス、統計情報（チェック数、該当数、割合）を返却
-/// - .git、.buildなどの不要なディレクトリは自動スキップ
+/// - .git、.build などの不要なディレクトリは自動スキップ
 ///
 /// ## 使用シーン
-/// - Code Headerフォーマットが未適用のファイルを探す時
-/// - Import文が欠けているファイルを洗い出す時
+/// - Code Header フォーマットが未適用のファイルを探す時
+/// - Import 文が欠けているファイルを洗い出す時
 /// - ドキュメント整備の進捗確認
 /// - 特定のマーカーやアノテーションの適用漏れチェック
 ///
 /// ## 使用例
-/// search_files_without_pattern(pattern: "\\[Code Header Format\\]")
+/// search_files_without_pattern(pattern: "\\[Code Header Format\\]", include_patterns: ["Sources/**/*.swift"])
 /// → Found 163 files without pattern:
 ///   UserManager.swift
 ///   AuthService.swift
@@ -42,19 +54,14 @@ import Logging
 ///   Files checked: 263
 ///   Files without pattern: 163 (61.9%)
 ///
-///
-/// ## search_codeとの違い
+/// ## search_code との違い
 /// - search_code: パターンに**マッチする**行を返す
-/// - search_files_without_pattern: パターンに**マッチしない**ファイルを返す（grep -L相当）
-///
-/// ## パフォーマンス（全ファイル処理する場合）
-/// - 263ファイルのプロジェクトで約1-2秒
-/// - 各ファイル全体を読み込むため、search_codeより若干遅い
+/// - search_files_without_pattern: パターンに**マッチしない**ファイルを返す（grep -L 相当）
 enum SearchFilesWithoutPatternTool: MCPTool {
     static var toolDefinition: Tool {
         Tool(
             name: ToolNames.searchFilesWithoutPattern,
-            description: "Find files that do NOT match the given pattern (like grep -L)",
+            description: "Find files that do NOT match the given pattern (like grep -L). Supports include_patterns / exclude_patterns (glob).",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
@@ -62,9 +69,23 @@ enum SearchFilesWithoutPatternTool: MCPTool {
                         "type": .string("string"),
                         "description": .string("Regex pattern to search for (files WITHOUT this pattern will be returned)")
                     ]),
-                    ParameterKeys.filePattern: .object([
-                        "type": .string("string"),
-                        "description": .string("Optional file pattern to limit search (e.g., '*.swift')")
+                    ParameterKeys.includePatterns: .object([
+                        "type": .string("array"),
+                        "description": .string(
+                            "Optional glob patterns to include (OR). Empty means default *.swift behavior. Max 20 entries."
+                        ),
+                        "items": .object([
+                            "type": .string("string")
+                        ])
+                    ]),
+                    ParameterKeys.excludePatterns: .object([
+                        "type": .string("array"),
+                        "description": .string(
+                            "Optional glob patterns to exclude (OR; wins over include). Max 20 entries."
+                        ),
+                        "items": .object([
+                            "type": .string("string")
+                        ])
                     ])
                 ]),
                 "required": .array([.string(ParameterKeys.pattern)])
@@ -78,22 +99,60 @@ enum SearchFilesWithoutPatternTool: MCPTool {
         logger: Logger
     ) async throws -> CallTool.Result {
         let memory = try ToolHelpers.requireProjectMemory(projectMemory)
+
         let pattern = try ToolHelpers.getString(
             from: params.arguments,
             key: ParameterKeys.pattern,
             errorMessage: ErrorMessages.missingPattern
         )
-        let filePattern: String?
-        if case .string(let s) = params.arguments?[ParameterKeys.filePattern] {
-            filePattern = s
-        } else {
-            filePattern = nil
+
+        // pattern: 正規表現構文の事前検証（Tool 層責務／DES-104 §4.0）
+        do {
+            _ = try NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines])
+        } catch {
+            return CallTool.Result(content: [
+                .text(ResultEncoder.buildErrorResponse(
+                    cause: ErrorMessages.regexSyntaxErrorCause,
+                    suggestion: ErrorMessages.regexSyntaxErrorSuggestion
+                ))
+            ])
+        }
+
+        let includePatterns: [String]
+        let excludePatterns: [String]
+        do {
+            includePatterns = try ToolHelpers.getStringArray(
+                from: params.arguments,
+                key: ParameterKeys.includePatterns,
+                maxCount: 20
+            )
+            excludePatterns = try ToolHelpers.getStringArray(
+                from: params.arguments,
+                key: ParameterKeys.excludePatterns,
+                maxCount: 20
+            )
+        } catch let MCPError.invalidParams(message) {
+            return CallTool.Result(content: [.text(stringArrayParameterErrorResponse(message))])
+        }
+
+        // include / exclude: glob 事前検証（wildcardToRegex + NSRegularExpression）
+        do {
+            try validateGlobSyntax(includePatterns)
+            try validateGlobSyntax(excludePatterns)
+        } catch {
+            return CallTool.Result(content: [
+                .text(ResultEncoder.buildErrorResponse(
+                    cause: ErrorMessages.globSyntaxErrorCause,
+                    suggestion: ErrorMessages.globSyntaxErrorSuggestion
+                ))
+            ])
         }
 
         let searchResult = try FileSearcher.searchFilesWithoutPattern(
             in: memory.projectPath,
             pattern: pattern,
-            filePattern: filePattern
+            includePatterns: includePatterns,
+            excludePatterns: excludePatterns
         )
         let filesWithoutPattern = searchResult.filesWithoutPattern
         let totalFiles = searchResult.totalChecked
@@ -109,5 +168,29 @@ enum SearchFilesWithoutPatternTool: MCPTool {
         result += "Files without pattern: \(filesWithoutCount) (\(String(format: "%.1f%%", percentage)))\n"
 
         return CallTool.Result(content: [.text(result)])
+    }
+
+    // MARK: - 入力検証ヘルパー
+
+    /// include / exclude の各要素が glob→正規表現変換後もコンパイル可能か検証する
+    private static func validateGlobSyntax(_ patterns: [String]) throws {
+        for glob in patterns {
+            let regexPattern = FileSearcher.wildcardToRegex(glob)
+            _ = try NSRegularExpression(pattern: regexPattern, options: [.caseInsensitive])
+        }
+    }
+
+    /// `getStringArray` の MCPError を DES-104 の統一エラー形式へ寄せる
+    private static func stringArrayParameterErrorResponse(_ message: String?) -> String {
+        if let message, message.contains("exceeds maximum element count") {
+            return ResultEncoder.buildErrorResponse(
+                cause: ErrorMessages.arrayCountExceededCause,
+                suggestion: ErrorMessages.arrayCountExceededSuggestion
+            )
+        }
+        return ResultEncoder.buildErrorResponse(
+            cause: "include_patterns または exclude_patterns が不正です。",
+            suggestion: message ?? ErrorMessages.globSyntaxErrorSuggestion
+        )
     }
 }

--- a/Tests/BackwardCompatibilityTests/BackwardCompatibilityTests.swift
+++ b/Tests/BackwardCompatibilityTests/BackwardCompatibilityTests.swift
@@ -408,7 +408,7 @@ final class BackwardCompatibilityTests: XCTestCase {
         let response = try await runSearchCode(arguments: [
             ParameterKeys.pattern: .string("hello"),
             ParameterKeys.outputMode: .string("file_list"),
-            ParameterKeys.filePattern: .string("*.md"),
+            "file_pattern": .string("*.md"),
         ])
 
         // エラー応答ではない（DES-104 §5.1 未知パラメータ無視方針）
@@ -440,6 +440,138 @@ final class BackwardCompatibilityTests: XCTestCase {
         XCTAssertTrue(
             files.allSatisfy { $0.hasSuffix(".swift") },
             "file_pattern 廃止後は include_patterns 未指定で .swift 既定挙動のみ"
+        )
+    }
+
+    // MARK: - search_files_without_pattern 入力契約テスト（issue #34）
+
+    /// 引数辞書から CallTool.Parameters を作成し SearchFilesWithoutPatternTool を実行する
+    private func runSearchFilesWithoutPattern(arguments: [String: Value]) async throws -> String {
+        let params = CallTool.Parameters(
+            name: ToolNames.searchFilesWithoutPattern,
+            arguments: arguments
+        )
+        let result = try await SearchFilesWithoutPatternTool.execute(
+            params: params,
+            projectMemory: projectMemory,
+            logger: logger
+        )
+        for content in result.content {
+            if case .text(let text, _, _) = content {
+                return text
+            }
+        }
+        XCTFail("CallTool.Result に text コンテンツが含まれていません")
+        return ""
+    }
+
+    /// `file_pattern` パラメータは issue #34 で `search_code` と同じ理由により廃止された
+    ///
+    /// 旧仕様: `file_pattern: String?` で単一 glob を受け付け
+    /// 新仕様: `include_patterns` / `exclude_patterns` の配列を受け付け
+    /// 互換挙動: 旧キー `file_pattern` を指定しても未知パラメータとして無視され、既定挙動（`.swift` のみ）が適用される
+    func test_searchFilesWithoutPattern_filePatternParameterIsRemoved_breakingChange_issue34() async throws {
+        // file_pattern="*.md" を渡しても無視され、include_patterns 未指定なら既定挙動（.swift のみ）が適用される
+        let response = try await runSearchFilesWithoutPattern(arguments: [
+            ParameterKeys.pattern: .string("hello"),
+            "file_pattern": .string("*.md"),
+        ])
+
+        // エラー応答ではない（未知パラメータ無視方針）
+        XCTAssertFalse(
+            response.hasPrefix("[Error]"),
+            "file_pattern 指定で InvalidParams は返さない（未知パラメータとして無視）"
+        )
+
+        // .md は対象に含まれてはならない（旧 file_pattern が効くと .md が走査されてしまう）
+        // 既定挙動: .swift のみ走査され、Sample.swift / SampleClass.swift（hello を含まない）が返る
+        let lines = response.components(separatedBy: "\n").filter { !$0.isEmpty }
+        let resultLines = lines.filter { $0.contains("/") }
+        XCTAssertFalse(
+            resultLines.contains(where: { $0.contains(".md") }),
+            "file_pattern 廃止後は .md ファイルが対象に含まれてはならない"
+        )
+        // Sample.swift / SampleClass.swift は hello を含まないため結果に含まれる
+        XCTAssertTrue(
+            resultLines.contains(where: { $0.hasSuffix("Sample.swift") }),
+            "既定挙動で hello を含まない Sample.swift が結果に含まれる"
+        )
+    }
+
+    /// include_patterns で対象を絞り込める（複数 glob OR）
+    func test_searchFilesWithoutPattern_includePatternsArrayRestrictsScope() async throws {
+        let response = try await runSearchFilesWithoutPattern(arguments: [
+            ParameterKeys.pattern: .string("hello"),
+            ParameterKeys.includePatterns: .array([.string("*Sample*")]),
+        ])
+
+        XCTAssertFalse(response.hasPrefix("[Error]"), "正常系で [Error] にならない")
+
+        // include_patterns=*Sample* で Sample.swift / SampleClass.swift のみ走査され
+        // 両者とも hello を含まないため、両方が結果に含まれる
+        let lines = response.components(separatedBy: "\n").filter { $0.contains("/") }
+        XCTAssertTrue(
+            lines.contains(where: { $0.hasSuffix("Sample.swift") }),
+            "Sample.swift（hello 非含有）が結果に含まれる"
+        )
+        XCTAssertTrue(
+            lines.contains(where: { $0.hasSuffix("SampleClass.swift") }),
+            "SampleClass.swift（hello 非含有）が結果に含まれる"
+        )
+        // Foo.swift / Bar.swift は include_patterns でそもそも走査対象外
+        XCTAssertFalse(
+            lines.contains(where: { $0.hasSuffix("Foo.swift") }),
+            "include_patterns=*Sample* なら Foo.swift は走査対象外"
+        )
+    }
+
+    /// exclude_patterns は include_patterns より優先される
+    func test_searchFilesWithoutPattern_excludePatternsOverridesInclude() async throws {
+        let response = try await runSearchFilesWithoutPattern(arguments: [
+            ParameterKeys.pattern: .string("hello"),
+            ParameterKeys.includePatterns: .array([.string("*.swift")]),
+            ParameterKeys.excludePatterns: .array([.string("*SampleClass*")]),
+        ])
+
+        XCTAssertFalse(response.hasPrefix("[Error]"), "正常系で [Error] にならない")
+
+        let lines = response.components(separatedBy: "\n").filter { $0.contains("/") }
+        // SampleClass.swift は exclude で除外され結果に含まれない
+        XCTAssertFalse(
+            lines.contains(where: { $0.hasSuffix("SampleClass.swift") }),
+            "exclude_patterns=*SampleClass* で除外されたファイルは結果に含まれない"
+        )
+        // Sample.swift（hello 非含有・除外対象外）は結果に含まれる
+        XCTAssertTrue(
+            lines.contains(where: { $0.hasSuffix("Sample.swift") }),
+            "exclude に該当しない Sample.swift は結果に残る"
+        )
+    }
+
+    /// include_patterns / exclude_patterns の配列要素 20 件超過は InvalidParams エラーを返す
+    func test_searchFilesWithoutPattern_arrayCountExceededReturnsError() async throws {
+        let manyPatterns: [Value] = (0..<21).map { _ in .string("*.swift") }
+        let response = try await runSearchFilesWithoutPattern(arguments: [
+            ParameterKeys.pattern: .string("hello"),
+            ParameterKeys.includePatterns: .array(manyPatterns),
+        ])
+
+        XCTAssertTrue(
+            response.contains("配列要素数が上限を超えています") || response.contains("[Error]"),
+            "include_patterns 21 件超で配列上限エラー応答（cause / suggestion 形式）"
+        )
+    }
+
+    /// 不正な正規表現は構文エラー応答を返す（Tool 層の事前検証）
+    func test_searchFilesWithoutPattern_invalidRegexReturnsError() async throws {
+        // 未閉じグループの不正な正規表現
+        let response = try await runSearchFilesWithoutPattern(arguments: [
+            ParameterKeys.pattern: .string("("),
+        ])
+
+        XCTAssertTrue(
+            response.contains("正規表現の構文が不正です") || response.contains("[Error]"),
+            "不正な正規表現で正規表現構文エラー応答（cause / suggestion 形式）"
         )
     }
 

--- a/Tests/SearchCodeToolTests/SearchCodeToolTests.swift
+++ b/Tests/SearchCodeToolTests/SearchCodeToolTests.swift
@@ -329,7 +329,7 @@ final class SearchCodeToolTests: XCTestCase {
         let response = try await runSearchCode(arguments: [
             ParameterKeys.pattern: .string("hello"),
             ParameterKeys.outputMode: .string("file_list"),
-            ParameterKeys.filePattern: .string("*.md"),
+            "file_pattern": .string("*.md"),
         ])
         let parts = splitStructured(response)
 

--- a/project/improve/design/DES-104_search_symbol_tools_enhancement_design.md
+++ b/project/improve/design/DES-104_search_symbol_tools_enhancement_design.md
@@ -377,7 +377,7 @@ v4 リリース直後に発覚した「**同一 cacheVersion 内で SymbolInfo �
 - `excludePatterns = "exclude_patterns"`
 
 削除する `ParameterKeys` 定数:
-- `filePattern = "file_pattern"`（`Sources/Constants.swift:58` を削除。`SearchFilesWithoutPatternTool` 等での同名パラメータ利用は別途 issue #34 で扱うため、本 Feature では `SearchCodeTool` 側の参照のみ削除し、`Constants.filePattern` 自体の削除可否は他ツールの修正完了を待って判断する）
+- `filePattern = "file_pattern"`（`Sources/Constants.swift` の定数自体を削除。issue #34 で `SearchFilesWithoutPatternTool` も `include_patterns` / `exclude_patterns` へ移行完了したため、共有定数を廃止する。両ツールでの `file_pattern` キー指定は §5.1 の方針に従い未知パラメータとして無視される）
 
 ### 5.2 出力モード別テキスト出力フォーマット
 
@@ -849,3 +849,4 @@ Reason: {判定失敗の理由}
 | 2026-05-04 | 1.2 | k2moons | テンプレート必須セクション補完 |
 | 2026-05-05 | 1.3 | k2moons | REQ-005 `file_pattern` 廃止反映 |
 | 2026-05-06 | 2.0 | k2moons | **大幅圧縮（拡大解釈の是正）**: ① CapabilityRegistry を最小実装に縮退（actor / 並列前提条件チェック / タイムアウト戦略 / キャンセル協調 / 状態機械を削除し、無条件で全ツール返す静的 enum 関数に変更）／② ProjectMemory v3→v4 移行時の notes 保持機構（LegacyNotesContainer による 2 段階デコード）を削除し全破棄方針に変更（REQ-005 要件外のため）／③ ModuleNameResolver を独立モジュールから SymbolVisitorV2 内のヘルパーメソッドに内包／④ §3.1 データフロー設計・§4.9 状態管理設計（§4.9.1 / §4.9.2）・§6.8 ユースケース設計・§12.1 テンプレートマッピングを削除（テンプレート準拠のための形式的セクションで実装に寄与しない）／⑤ §4.8 ListTools 切り替えシーケンス図を削除／⑥ §6.5 並存 3 型表を §6.4 に集約／⑦ 1193 行 → 833 行（約 30% 削減）に圧縮 |
+| 2026-05-17 | 2.1 | k2moons | issue #34 対応反映: `SearchFilesWithoutPatternTool` も `file_pattern` を廃止し `include_patterns` / `exclude_patterns` へ統一。`Sources/Constants.swift` の `ParameterKeys.filePattern` 共有定数を完全削除。§5.1 の `file_pattern` 未知パラメータ無視方針は両ツールに適用される |


### PR DESCRIPTION
## Summary

`search_files_without_pattern` の `file_pattern` パラメータを廃止し、`search_code` と同一の `include_patterns` / `exclude_patterns`（glob 配列）へ統一する。

- DES-104 §5.1 に従い `file_pattern` 等の未知パラメータは無視（エラーにしない）
- `FileSearcher.searchFilesWithoutPattern` を `includePatterns` / `excludePatterns` 引数に刷新し、`searchCode` と共通の `shouldSearchFile` / `compiledGlobRegexes` ヘルパを再利用
- `Sources/Constants.swift` から `ParameterKeys.filePattern` 共有定数を完全削除
- DES-104 を v2.1 に更新、CHANGELOG に v0.6.9 エントリを追記

## なぜ統一するか

LLM クライアントから利用する MCP ツール群で、検索系ツールのパラメータ名が分かれている（`file_pattern` 単独文字列 vs `include_patterns` / `exclude_patterns` 配列）と、ツール選択時に毎回スキーマを参照する必要が生じ、認知負荷が高い。`search_code` と `search_files_without_pattern` は「対象ファイル集合 × パターン」の構造が同じなので、API も揃える。

## Test plan

- [x] `swift build` クリーン
- [x] `swift test` 全 56 テスト pass
- [x] BackwardCompatibilityTests に 5 ケース追加（全 pass）
  - `file_pattern` 廃止確認（破壊的変更）
  - `include_patterns` 絞り込み
  - `exclude_patterns` 優先適用
  - 配列要素数上限エラー
  - 不正正規表現エラー
- [x] MCP サーバー再起動後の E2E 検証
  - スキーマ更新（`file_pattern` 消滅 / `include_patterns`・`exclude_patterns` 追加）
  - `include_patterns` 絞り込み（Sources/**/*.swift で 35 件走査）
  - `exclude_patterns` 除外（Visitors/ + Meta/ 除外で 35→22 件）
  - `file_pattern` 渡しても無視（結果が `include_patterns` 単独と完全一致）
  - 不正正規表現の cause/suggestion 応答
  - 配列要素数 21 件の cause/suggestion 応答

Closes #34