### PR TITLE
[Docs] file_pattern 残存箇所のドキュメント補正

### DIFF
--- a/.claude/skills/mcp-test/SKILL.md
+++ b/.claude/skills/mcp-test/SKILL.md
@@ -53,8 +53,8 @@ mcp__swift-selena-debug__list_available_tools
 | ツール | テストパラメータ | 成功判定 |
 |--------|-----------------|----------|
 | `find_files` | `pattern: "*.swift"` | 1件以上のファイルが返る |
-| `search_code` | `pattern: "import", file_pattern: "*.swift"` | マッチが返る（file_pattern 修正の検証を兼ねる） |
-| `search_files_without_pattern` | `pattern: "ToolProtocol", file_pattern: "*.swift"` | パターン不含ファイルが返る |
+| `search_code` | `pattern: "import", include_patterns: ["**/*.swift"]` | マッチが返る（DES-104 §5.1 / REQ-005 の include_patterns 検証を兼ねる） |
+| `search_files_without_pattern` | `pattern: "ToolProtocol", include_patterns: ["**/*.swift"]` | パターン不含ファイルが返る（issue #34 の include_patterns 検証を兼ねる） |
 | `list_symbols` | `file_path:` Sources/ 配下の任意の .swift ファイル | シンボル一覧が返る |
 | `find_symbol_definition` | `symbol_name:` プロジェクト内の既知の型名 | 定義箇所が返る |
 | `list_property_wrappers` | `file_path:` Tests/Fixtures/TestSwiftUIView.swift | @State 等が検出される |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Swift-Selenaのリリース履歴
   - 配列要素数上限超過のエラー応答
   - 不正な正規表現のエラー応答
 - **docs**: DES-104 を v2.1 に更新（issue #34 対応反映、両ツールへの §5.1 適用を明記）
+- **docs**: `REQ-003_Core_Features_Requirements.md` の `search_code` 入力欄を `include_patterns` / `exclude_patterns` に修正（v0.6.8 反映漏れの遡及補正）
+- **docs**: `mcp-test` Skill のテストパラメータ（`search_code` / `search_files_without_pattern`）を `file_pattern` から `include_patterns` に更新
 
 ---
 

--- a/project/main/spec/REQ-003_Core_Features_Requirements.md
+++ b/project/main/spec/REQ-003_Core_Features_Requirements.md
@@ -145,7 +145,10 @@ UC: テストファイルを列挙
 
 **入力:**
 - `pattern`: 正規表現
-- `file_pattern`: ファイルフィルタ（オプション）
+- `include_patterns`: 対象に含める glob 配列（オプション、最大 20 件）
+- `exclude_patterns`: 対象から除外する glob 配列（オプション、最大 20 件、include に勝つ）
+
+> v0.6.8 (REQ-005 / DES-104 §5.1) で `file_pattern` 単独パラメータを廃止し、`search_files_without_pattern` と共通の `include_patterns` / `exclude_patterns` 配列に統一した。
 
 **出力:**
 ```


### PR DESCRIPTION
## 概要

- PR #35 (issue #34) で `search_files_without_pattern` を `include_patterns` / `exclude_patterns` に統一した後の追加ドキュメント補正
- v0.6.8 (REQ-005 / DES-104 §5.1) で `search_code` の `file_pattern` を廃止した際の文書反映漏れも併発発見したため遡及補正

## 背景

PR #35 マージ後の文書全件調査で、`file_pattern` への古い言及が以下の 2 箇所に残存していることを確認:

- `.claude/skills/mcp-test/SKILL.md` L56-57: テストパラメータが `file_pattern: "*.swift"` のまま
- `project/main/spec/REQ-003_Core_Features_Requirements.md` L148: `search_code` 入力欄に `file_pattern: ファイルフィルタ（オプション）` が残存（v0.6.8 反映漏れ）

`README.md` / `README.ja.md` / `CLAUDE.md` には `file_pattern` への言及がなく更新不要であることも確認済み。

## やったこと

- `mcp-test` Skill のテストパラメータを `search_code` / `search_files_without_pattern` ともに `include_patterns: [\"**/*.swift\"]` へ更新
- REQ-003 の `search_code` 入力欄を `include_patterns` / `exclude_patterns` 配列（各最大 20 件）へ修正し、v0.6.8 の経緯を注記
- CHANGELOG v0.6.9 セクションに上記 2 件のドキュメント更新を追記

## やらないこと

- README.md / README.ja.md / CLAUDE.md: `file_pattern` 言及がないため更新対象外
- `project/main/plan/main_plan.md`: 過去のリリース履歴の事実記述として現状維持
- Sources/ 内のコメント: 「\`file_pattern\` を廃止した」という説明として正しい記述のため現状維持

## レビュー観点

- `mcp-test` のテストケースで `include_patterns: [\"**/*.swift\"]` がデフォルト挙動と等価（include 空時の \*.swift 動作）になっている点が、テスト意図として妥当か
- REQ-003 の修正注記（v0.6.8 / REQ-005 / DES-104 §5.1 への参照）が要件文書として適切か

## レビューレベル

- ~~Lv0: まったく見ないでAcceptする~~
- ~~Lv1: ぱっとみて違和感がないかチェックしてAcceptする~~
- Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証してAcceptする
- ~~Lv3: 実際に環境で動作確認したうえでAcceptする~~

## 備考

Refs #34 / PR #35