### PR TITLE
[Chore] バージョン表記規約のレビュー対応（#38 follow-up）

### DIFF
--- a/.github/workflows/version_check.yml
+++ b/.github/workflows/version_check.yml
@@ -8,7 +8,6 @@ on:
     paths:
       - 'Sources/Constants.swift'
       - '.version-config.yaml'
-      - 'Formula/swift-selena.rb'
       - 'CHANGELOG.md'
       - 'scripts/verify_version_consistency.sh'
       - '.github/workflows/version_check.yml'

--- a/.version-config.yaml
+++ b/.version-config.yaml
@@ -3,7 +3,7 @@
 targets:
   - name: swift-selena
     version_file: Sources/Constants.swift
-    version_path: "version"
+    version_path: version
     sync_files: []
 
 changelog:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,21 +34,27 @@ Swift-Selena = MCP Server for Swift code analysis (Swift Package)
   - **CHANGELOG.md header (新規 entry)**: `## VERSION - YYYY-MM-DD` 形式（**`v` プレフィックスなし**、例: `## 0.6.10 - 2026-05-27`）。過去 entry (`## v0.6.X` 形式) は historical record として遡及修正しない
   - **`.version-config.yaml`** の `tag_format` は `"{version}"`（`v` なし）
   - **例外**: `README.md` / `README.ja.md` 内の「機能 X は v0.6.3 以降で利用可能」等の**機能登場版マーカー**は `v` 付きを許容（独立した文脈表記）
-  - **検証**: `scripts/verify_version_consistency.sh` で全 source の一致を確認。CI ワークフロー `.github/workflows/version_check.yml` で PR ごとに自動検証
+  - **検証**: `scripts/verify_version_consistency.sh` で canonical（`Sources/Constants.swift`）・CHANGELOG 先頭 entry・`.version-config.yaml` の `tag_format` / `version_file` / `version_path` の一致を確認。CI ワークフロー `.github/workflows/version_check.yml` で PR ごとに自動検証
+  - **Formula は verify 対象外**: `Formula/swift-selena.rb` の `tag:` / `revision:` は git tag ライフサイクルに従属し（`revision` は tag が指す commit の SHA）、version bump 時点では確定できないため、verify script の必須チェックには含めない。Formula の整合性は後述の release フロー Phase 3 と `brew install` 実検証で担保する
 - **リリースタグは main ブランチで作成する**: `{version}` 形式（**`v` プレフィックスなし**）のリリースタグは、必ず **main ブランチ上のコミット**に対して作成すること
   - `develop` 等の作業ブランチ上で `git tag` を実行しない
   - 通常フロー: `develop` の変更を `main` にマージ（PR / merge commit）→ `main` に checkout → `git tag {version}` → `git push <remote> {version}`
   - タグ作成前に `git branch --show-current` で必ず main ブランチに居ることを確認する
   - 誤って別ブランチで作成したタグは `git tag -d <tag> && git push <remote> :<tag>` で削除し、正しいブランチで切り直す
-- **release PR の運用順序（同一 PR で完結させる）**: version bump を含む release PR は以下を**同一 PR 内**で実施する。CI が赤になる期間を作らないため
-  1. `/forge:update-version <target> <patch|minor|major>` を実行（Constants.swift 更新 + CHANGELOG への新規 entry 挿入）
-  2. `Formula/swift-selena.rb` の `tag:` と `revision:` を**手動で同時更新**
-     - tag 作成前の段階では HEAD commit SHA を仮で記入し、tag 作成後に最終 revision に差し替える運用も可（または tag 作成 → revision 取得 → Formula 更新 → tag 振り直しの順序でも可）
-  3. `scripts/verify_version_consistency.sh` でローカル検証
-  4. `brew style Formula/swift-selena.rb` で Formula 文法検証
-  5. commit & push（PR は同一 PR で）
-  6. PR merge 後、`main` に checkout して `git tag {version}` → `git push <remote> {version}` でリリースタグ作成
-  7. tap merge 後、`brew install --build-from-source` で実 install 検証
+- **release の運用順序（3 フェーズ）**: Homebrew Formula の `revision` は「tag が指す commit の SHA」であり、tag を打つまで確定しない。したがって version bump と Formula 更新を同一 PR で完結させることは**原理的に不可能**。以下の 3 フェーズに分けて実施する
+  - **Phase 1 — version bump PR**:
+    1. `/forge:update-version <target> <patch|minor|major>` を実行（`Sources/Constants.swift` 更新 + CHANGELOG への新規 entry 挿入）
+    2. `scripts/verify_version_consistency.sh` でローカル検証（Formula は対象外なので、この時点で Formula が旧 tag のままでも検証は通る）
+    3. commit & push し、`develop` 等の作業ブランチで PR を作成・マージ
+  - **Phase 2 — リリースタグ作成（main 上）**:
+    4. `develop` の変更を `main` にマージ（PR / merge commit）
+    5. `main` に checkout し、`git branch --show-current` で main に居ることを確認した上で `git tag {version}` → `git push <remote> {version}`
+    6. `git rev-parse {version}^{commit}` で tag が指す commit の SHA（= Formula の `revision` に書く値）を取得
+  - **Phase 3 — Formula bump PR**:
+    7. `Formula/swift-selena.rb` の `tag:` を `{version}`、`revision:` を Phase 2-6 で取得した SHA に更新
+    8. `brew style Formula/swift-selena.rb` で Formula 文法検証
+    9. commit & push し、PR を作成・マージ
+    10. tap merge 後、`brew install --build-from-source` で実 install 検証
 - **既存 release artifact の drift について（documented limitation）**: 本規約は HEAD 以降で commit される変更にのみ適用される。既存 release tag（例: `0.6.10`）のソース内 `AppConstants.version` 等が drift していても、本規約では遡及修正しない（git 履歴の整合性保持）。Homebrew で install される既存 release バイナリの `serverInfo.version` が canonical と一致しない場合、それは「既知の historical drift」として受容し、次回 release で初めて完全整合する
 
 ## 開発言語・フレームワーク

--- a/scripts/verify_version_consistency.sh
+++ b/scripts/verify_version_consistency.sh
@@ -2,10 +2,17 @@
 # プロジェクト内のバージョン表記が整合していることを検証する。
 #
 # canonical: Sources/Constants.swift の `static let version = "X.Y.Z"` 行
-# 比較対象:
+# 検証項目:
+#   - CHANGELOG.md の最新「v なし」entry (`## VERSION - DATE`) の VERSION が canonical と一致
 #   - .version-config.yaml の tag_format が "{version}"
-#   - Formula/swift-selena.rb の tag: "X.Y.Z" が canonical と一致
-#   - CHANGELOG.md の最新「v なし」entry (`## VERSION - DATE`) の VERSION 部分が canonical と一致
+#   - .version-config.yaml の version_file が Sources/Constants.swift
+#   - .version-config.yaml の version_path が version
+#
+# Formula/swift-selena.rb は検証対象外。
+#   理由: Formula の tag/revision は git tag ライフサイクルに従属し
+#   （revision = tag が指す commit の SHA）、version bump 時点では確定できない。
+#   Formula の整合性は release フロー Phase 3 と `brew install` 実検証で担保する
+#   （CLAUDE.md「release の運用順序」参照）。
 #
 # 全て一致 → exit 0
 # いずれか不一致 → 検出内容を stderr に列挙して exit 1
@@ -30,33 +37,6 @@ echo "canonical (Sources/Constants.swift): $canonical"
 
 errors=0
 
-# .version-config.yaml の tag_format
-tag_format=$(grep -E '^\s*tag_format:' .version-config.yaml \
-  | sed -E 's/.*tag_format:[[:space:]]*"?([^"#]+)"?.*/\1/' \
-  | head -1 \
-  | sed -E 's/[[:space:]]+$//')
-if [ "$tag_format" != "{version}" ]; then
-  echo "ERROR: .version-config.yaml tag_format must be \"{version}\" (v なし), got: '$tag_format'" >&2
-  errors=$((errors + 1))
-else
-  echo "ok    .version-config.yaml tag_format: \"{version}\""
-fi
-
-# Formula/swift-selena.rb の tag
-if [ -f Formula/swift-selena.rb ]; then
-  formula_tag=$(grep -E '^\s*tag:[[:space:]]+"' Formula/swift-selena.rb \
-    | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/' \
-    | head -1)
-  if [ "$formula_tag" != "$canonical" ]; then
-    echo "ERROR: Formula/swift-selena.rb tag is '$formula_tag', expected '$canonical' (canonical)" >&2
-    errors=$((errors + 1))
-  else
-    echo "ok    Formula/swift-selena.rb tag: \"$formula_tag\""
-  fi
-else
-  echo "warn  Formula/swift-selena.rb not present (skipping)"
-fi
-
 # CHANGELOG.md の最新「v なし」entry
 # 過去の `## v0.6.X` 表記は historical record として skip し、`## X.Y.Z` 形式の最初のヒットを取る
 changelog_latest=$(grep -E '^## [0-9]+\.[0-9]+\.[0-9]+([[:space:]]|$)' CHANGELOG.md \
@@ -70,6 +50,42 @@ elif [ "$changelog_latest" != "$canonical" ]; then
   errors=$((errors + 1))
 else
   echo "ok    CHANGELOG.md latest non-v entry: $changelog_latest"
+fi
+
+# .version-config.yaml の tag_format
+tag_format=$(grep -E '^\s*tag_format:' .version-config.yaml \
+  | sed -E 's/.*tag_format:[[:space:]]*"?([^"#]+)"?.*/\1/' \
+  | head -1 \
+  | sed -E 's/[[:space:]]+$//')
+if [ "$tag_format" != "{version}" ]; then
+  echo "ERROR: .version-config.yaml tag_format must be \"{version}\" (v なし), got: '$tag_format'" >&2
+  errors=$((errors + 1))
+else
+  echo "ok    .version-config.yaml tag_format: \"{version}\""
+fi
+
+# .version-config.yaml の version_file（canonical を指しているか）
+version_file=$(grep -E '^\s*version_file:' .version-config.yaml \
+  | sed -E 's/.*version_file:[[:space:]]*"?([^"#]+)"?.*/\1/' \
+  | head -1 \
+  | sed -E 's/[[:space:]]+$//')
+if [ "$version_file" != "Sources/Constants.swift" ]; then
+  echo "ERROR: .version-config.yaml version_file must be 'Sources/Constants.swift' (canonical), got: '$version_file'" >&2
+  errors=$((errors + 1))
+else
+  echo "ok    .version-config.yaml version_file: Sources/Constants.swift"
+fi
+
+# .version-config.yaml の version_path（引用符なしの version であること）
+version_path=$(grep -E '^\s*version_path:' .version-config.yaml \
+  | sed -E 's/.*version_path:[[:space:]]*"?([^"#]+)"?.*/\1/' \
+  | head -1 \
+  | sed -E 's/[[:space:]]+$//')
+if [ "$version_path" != "version" ]; then
+  echo "ERROR: .version-config.yaml version_path must be 'version' (引用符なし), got: '$version_path'" >&2
+  errors=$((errors + 1))
+else
+  echo "ok    .version-config.yaml version_path: version"
 fi
 
 if [ "$errors" -eq 0 ]; then


### PR DESCRIPTION
## 概要

- Issue #38（バージョン表記の統一）のレビュー対応 follow-up。本体 commit `366da88`（develop マージ済み）への追補。

## 背景

- #38 本体マージ後のレビューで、release 運用手順の原理的破綻・verify script の検証漏れ・`version_path` の引用符問題が指摘された。

## やったこと

- **CLAUDE.md**: release 手順を「同一 PR で完結」（Formula の `revision` は tag 確定後にしか書けず原理的に不可能）から **3 フェーズフロー**（①version bump PR → ②main で tag + SHA 取得 → ③Formula bump PR + `brew install` 検証）に書き換え。verify が Formula を対象外とする旨も明記。
- **scripts/verify_version_consistency.sh**: Formula チェックを削除（git tag ライフサイクルに従属するため `brew` 検証に委譲）。代わりに `.version-config.yaml` の `version_file` / `version_path` が canonical を指すことの検証を追加。
- **.version-config.yaml**: `version_path: "version"` → `version`（引用符なし。`update_version_files.py` が引用符込みで失敗するため）。
- **.github/workflows/version_check.yml**: trigger paths から Formula を除外（verifier が参照しなくなったことと整合）。

## やらないこと（このプルリクエストのスコープ外とすること）

- 既存 `0.6.10` release artifact の drift 修正（git 履歴の事実、次回 release で解消）。
- Formula 本体の変更（#37 で導入済み、次回 release 時に手動 bump）。
- forge `/forge:update-version` 自体の改善（simple 形式 CHANGELOG 挿入・`version_path` 引用符の根本対応）。upstream の BlueEventHorizon/bw-cc-plugins#115 に起票済み。

## 画面設計書

該当なし（非 UI）。

## デザイン仕様書

該当なし。

## API仕様書

該当なし。

## レビュー観点

- release 3 フェーズフローの記述が原理的に正しいか（特に Formula `revision` = tag が指す commit の SHA という依存関係）。
- verify script が Formula を検証対象外にした判断の妥当性。
- `bash scripts/verify_version_consistency.sh` がローカルで通ること（all sources == `0.6.10`）は確認済み。

## レビューレベル

- ~~Lv0: まったく見ないでAcceptする~~
- ~~Lv1: ぱっとみて違和感がないかチェックしてAcceptする~~
- Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証してAcceptする
- ~~Lv3: 実際に環境で動作確認したうえでAcceptする~~

## スクリーンショット

該当なし。

## 備考

- Issue #38 のクローズは本体 commit `366da88`（`Closes #38`）が main にマージされた時点で発火する。本 PR は develop への follow-up のため `Refs #38`。
- 関連 upstream issue: BlueEventHorizon/bw-cc-plugins#115

Refs #38
