### PR TITLE
[Docs] README をエンドユーザー導線に集約し、開発者向け手順を CONTRIBUTING へ移動

### DIFF
--- a/CONTRIBUTING.ja.md
+++ b/CONTRIBUTING.ja.md
@@ -2,9 +2,96 @@
 
 Issue、Pull Request を歓迎します！
 
-ビルド・セットアップ・使い方は [README](README.ja.md) を参照してください。
+使い方と Homebrew でのインストールは [README](README.md) を参照してください。本ガイドは **ソースからのビルド**・**ローカル開発セットアップ**・**リリース手順** を扱います。
 
 English version: [CONTRIBUTING.md](CONTRIBUTING.md)
+
+## ソースからのビルド
+
+```bash
+git clone https://github.com/BlueEventHorizon/Swift-Selena.git
+cd Swift-Selena
+
+# リリースビルド（本番用）
+make build-release
+# または直接: swift build -c release -Xswiftc -Osize
+
+# デバッグビルド
+make build
+```
+
+ビルド成果物は `.build/release/Swift-Selena`（または `.build/debug/Swift-Selena`）に生成されます。
+
+### 利用可能な Make コマンド
+
+```bash
+make help  # 全コマンドを表示
+```
+
+| コマンド | 対象 | 説明 |
+|---------|------|------|
+| `make build` | — | DEBUG ビルド |
+| `make build-release` | — | RELEASE ビルド |
+| `make clean` | — | ビルド成果物をクリーン |
+| `make connect_gemini` | Claude Code | gemini-cli MCP サーバーを接続 |
+| `make disconnect_gemini` | Claude Code | gemini-cli MCP サーバーを切断 |
+| `make register-release` | Claude Code | RELEASE 版を登録（プロジェクトパスを入力） |
+| `make unregister-release` | Claude Code | RELEASE 版の登録を解除（プロジェクトパスを入力） |
+| `make register-debug` | Claude Code | DEBUG 版をビルド＆Swift-Selena プロジェクトに登録 |
+| `make unregister-debug` | Claude Code | DEBUG 版を Swift-Selena プロジェクトから解除 |
+| `make register-desktop` | Claude Desktop | Claude Desktop に登録 |
+| `make unregister-desktop` | Claude Desktop | Claude Desktop から解除 |
+
+## 開発セットアップ
+
+ローカルでビルドしたバイナリを（Homebrew のリリース版ではなく）Claude に登録するには、make ヘルパーか手動設定を使います。
+
+### make を使う（開発時の推奨）
+
+```bash
+# Claude Desktop
+make register-desktop
+
+# Claude Code — 対象プロジェクトに登録
+make register-release       # → 対象プロジェクトのパスを入力
+
+# Claude Code — DEBUG ビルドを Swift-Selena プロジェクト自体に登録
+make register-debug
+```
+
+登録解除:
+
+```bash
+make unregister-desktop
+make unregister-release      # → 対象プロジェクトのパスを入力（空白でカレントディレクトリ）
+make unregister-debug
+```
+
+### 手動設定
+
+**Claude Desktop** — `~/Library/Application Support/Claude/claude_desktop_config.json` を編集:
+
+```json
+{
+  "mcpServers": {
+    "swift-selena": {
+      "command": "/path/to/Swift-Selena/.build/release/Swift-Selena",
+      "env": { "MCP_CLIENT_ID": "claude-desktop" }
+    }
+  },
+  "isUsingBuiltInNodeForMcp": true
+}
+```
+
+`/path/to/Swift-Selena` を実際のパスに置き換え、Claude Desktop を再起動してください。
+
+**Claude Code** — 対象プロジェクトのディレクトリで:
+
+```bash
+claude mcp add swift-selena -- /path/to/Swift-Selena/.build/release/Swift-Selena
+# グローバル（全プロジェクト）:
+claude mcp add -s user swift-selena -- /path/to/Swift-Selena/.build/release/Swift-Selena
+```
 
 ## リリース手順（メンテナ向け）
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,96 @@
 
 Issues and Pull Requests are welcome!
 
-For build, setup, and usage instructions, see the [README](README.md).
+For usage and Homebrew installation, see the [README](README_en.md). This guide covers **building from source**, **local development setup**, and the **release procedure**.
 
 Japanese version: [CONTRIBUTING.ja.md](CONTRIBUTING.ja.md)
+
+## Building from source
+
+```bash
+git clone https://github.com/BlueEventHorizon/Swift-Selena.git
+cd Swift-Selena
+
+# Release build (production)
+make build-release
+# Or directly: swift build -c release -Xswiftc -Osize
+
+# Debug build
+make build
+```
+
+The build artifact is generated at `.build/release/Swift-Selena` (or `.build/debug/Swift-Selena`).
+
+### Available Make Commands
+
+```bash
+make help  # Show all available commands
+```
+
+| Command | Target | Description |
+|---------|--------|-------------|
+| `make build` | — | Build debug version |
+| `make build-release` | — | Build release version |
+| `make clean` | — | Clean build artifacts |
+| `make connect_gemini` | Claude Code | Connect gemini-cli MCP server |
+| `make disconnect_gemini` | Claude Code | Disconnect gemini-cli MCP server |
+| `make register-release` | Claude Code | Register RELEASE version (prompts for project path) |
+| `make unregister-release` | Claude Code | Unregister RELEASE version (prompts for project path) |
+| `make register-debug` | Claude Code | Build & register DEBUG version to the Swift-Selena project |
+| `make unregister-debug` | Claude Code | Unregister DEBUG version from the Swift-Selena project |
+| `make register-desktop` | Claude Desktop | Register to Claude Desktop |
+| `make unregister-desktop` | Claude Desktop | Unregister from Claude Desktop |
+
+## Development setup
+
+To register your locally-built binary with Claude (instead of the Homebrew release), use either the make helpers or manual configuration.
+
+### Using make (recommended for development)
+
+```bash
+# Claude Desktop
+make register-desktop
+
+# Claude Code — register to a target project
+make register-release       # → prompts for the target project path
+
+# Claude Code — register the DEBUG build to the Swift-Selena project itself
+make register-debug
+```
+
+Unregister:
+
+```bash
+make unregister-desktop
+make unregister-release      # → prompts for the target project path (blank = current dir)
+make unregister-debug
+```
+
+### Manual configuration
+
+**Claude Desktop** — edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "swift-selena": {
+      "command": "/path/to/Swift-Selena/.build/release/Swift-Selena",
+      "env": { "MCP_CLIENT_ID": "claude-desktop" }
+    }
+  },
+  "isUsingBuiltInNodeForMcp": true
+}
+```
+
+Replace `/path/to/Swift-Selena` with the actual path, then restart Claude Desktop.
+
+**Claude Code** — in your target project directory:
+
+```bash
+claude mcp add swift-selena -- /path/to/Swift-Selena/.build/release/Swift-Selena
+# Global (all projects):
+claude mcp add -s user swift-selena -- /path/to/Swift-Selena/.build/release/Swift-Selena
+```
 
 ## Release procedure (maintainers)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Platform macOS](https://img.shields.io/badge/platform-macOS%2013+-lightgrey.svg)](https://www.apple.com/macos/)
 [![License MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-[English version](README.md)
+[English version](README_en.md)
 
 ## 主な特徴
 
@@ -131,51 +131,22 @@ brew --prefix
 
 ### ビルド手順（代替: ソースビルド）
 
+Homebrew が使えない環境（制限された環境など）では、手動でビルド・登録します:
+
 ```bash
-# リポジトリをクローン
 git clone https://github.com/BlueEventHorizon/Swift-Selena.git
 cd Swift-Selena
-
-# ビルド（本番用リリースモード）
-make build-release
-
-# または直接swiftコマンドを使用：
-# swift build -c release -Xswiftc -Osize
+swift build -c release -Xswiftc -Osize
+# 成果物: .build/release/Swift-Selena
 ```
 
-ビルド成果物は `.build/release/Swift-Selena` に生成されます。
-
-### 利用可能なMakeコマンド
+ビルドしたバイナリを Claude Code に登録:
 
 ```bash
-make help  # 全コマンドを表示
+claude mcp add -s user swift-selena -- "$(pwd)/.build/release/Swift-Selena"
 ```
 
-#### ビルド
-
-| コマンド | 説明 |
-|---------|------|
-| `make build` | DEBUGビルド |
-| `make build-release` | RELEASEビルド |
-| `make clean` | ビルド成果物をクリーン |
-
-#### MCP補助
-
-| コマンド | 対象 | 説明 |
-|---------|------|------|
-| `make connect_gemini` | Claude Code | gemini-cli MCPサーバーを接続 |
-| `make disconnect_gemini` | Claude Code | gemini-cli MCPサーバーを切断 |
-
-#### 登録・解除
-
-| コマンド | 対象 | 説明 |
-|---------|------|------|
-| `make register-release` | Claude Code | RELEASE版を登録（プロジェクトパスを入力） |
-| `make unregister-release` | Claude Code | RELEASE版の登録を解除（プロジェクトパスを入力） |
-| `make register-debug` | Claude Code | DEBUG版をビルド＆Swift-Selenaプロジェクトに登録 |
-| `make unregister-debug` | Claude Code | DEBUG版をSwift-Selenaプロジェクトから解除 |
-| `make register-desktop` | Claude Desktop | Claude Desktopに登録 |
-| `make unregister-desktop` | Claude Desktop | Claude Desktopから解除 |
+> すべての `make` コマンド・ローカル開発時の登録・リリース手順は **[CONTRIBUTING.ja.md](CONTRIBUTING.ja.md)** を参照してください。
 
 ## デバッグ・ログ機能
 
@@ -208,91 +179,6 @@ tail -f ~/.swift-selena/logs/server.log
 ```
 
 **ヒント:** Swift-Selena使用中は、別のターミナルで`tail -f`を実行し続けておくと、リアルタイムデバッグが可能です。
-
-## セットアップ
-
-### 簡単セットアップ（ソースビルド時）
-
-Swift-Selenaプロジェクトルートでmakeコマンドを使用します：
-
-#### Claude Desktopの場合
-```bash
-make register-desktop
-```
-
-#### Claude Codeの場合
-
-```bash
-# 本番用（ターゲットプロジェクトに登録）
-make register-release
-# → プロンプト: 登録先プロジェクトのパスを入力
-
-# 開発・テスト用（Swift-Selenaプロジェクト自体に登録）
-make register-debug
-```
-
-#### 登録解除
-
-```bash
-# Claude Desktopから解除
-make unregister-desktop
-
-# ターゲットプロジェクトから解除
-make unregister-release
-# → プロンプト: 登録解除するプロジェクトのパスを入力（空白でカレントディレクトリ）
-
-# DEBUG版をこのプロジェクトから解除
-make unregister-debug
-```
-
-### 手動セットアップ
-
-スクリプトを使わず手動で設定する場合：
-
-#### Claude Desktop の設定
-
-1. 設定ファイルを開く（存在しない場合は作成）:
-```bash
-open ~/Library/Application\ Support/Claude/claude_desktop_config.json
-```
-
-2. 以下の内容を追加:
-```json
-{
-  "mcpServers": {
-    "swift-selena": {
-      "command": "/path/to/Swift-Selena/.build/release/Swift-Selena",
-      "env": {
-        "MCP_CLIENT_ID": "claude-desktop"
-      }
-    }
-  },
-  "isUsingBuiltInNodeForMcp": true
-}
-```
-
-**重要**: `/path/to/Swift-Selena` を実際のパスに置き換えてください。
-
-3. Claude Desktopを再起動
-
-#### Claude Code 手動設定
-
-ターゲットプロジェクトのディレクトリで：
-
-```bash
-cd /path/to/your/project
-claude mcp add swift-selena -- /path/to/Swift-Selena/.build/release/Swift-Selena
-```
-
-これでそのプロジェクトのみで有効なローカル設定が作成されます。
-
-**グローバルに使用する場合**（全プロジェクトで有効）：
-```bash
-cd ~
-claude mcp add -s user swift-selena -- /path/to/Swift-Selena/.build/release/Swift-Selena
-```
-
-詳細は[Claude Codeドキュメント](https://docs.claude.com/claude-code)を参照してください。
 
 ## 使い方
 
@@ -413,18 +299,15 @@ Params:
 
 ### MCPサーバーが起動しない
 
+バイナリが起動し、開始バナーを表示するか確認します:
+
 ```bash
-# DEBUGビルドを確認
-swift build
-
-# またはRELEASEビルドを確認
-swift build -c release -Xswiftc -Osize
-
-# RELEASE実行ファイルをテスト
-.build/release/Swift-Selena
-# "Starting Swift MCP Server..." が表示されればOK
-# Ctrl+Cで終了
+# Homebrew でインストールした場合
+swift-selena
+# "Starting Swift MCP Server..." が表示されればOK。Ctrl+C で終了
 ```
+
+ソースからビルドした場合は `.build/release/Swift-Selena` を実行してください（[CONTRIBUTING.ja.md](CONTRIBUTING.ja.md) 参照）。
 
 ### ツールが見つからない
 
@@ -454,7 +337,7 @@ rm -rf ~/.swift-selena/
 {
   "mcpServers": {
     "swift-selena": {
-      "command": "/path/to/Swift-Selena/.build/release/Swift-Selena",
+      "command": "/opt/homebrew/bin/swift-selena",
       "env": {
         "MCP_CLIENT_ID": "claude-desktop",
         "SWIFT_SELENA_LEGACY": "1"
@@ -466,7 +349,7 @@ rm -rf ~/.swift-selena/
 
 #### Claude Code
 ```bash
-claude mcp add swift-selena -e SWIFT_SELENA_LEGACY=1 -- /path/to/Swift-Selena/.build/release/Swift-Selena
+claude mcp add swift-selena -e SWIFT_SELENA_LEGACY=1 -- swift-selena
 ```
 
 レガシーモードでは、以下12個のツールが直接公開されます：

--- a/README_en.md
+++ b/README_en.md
@@ -8,7 +8,7 @@
 [![Platform macOS](https://img.shields.io/badge/platform-macOS%2013+-lightgrey.svg)](https://www.apple.com/macos/)
 [![License MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-[日本語版はこちら / Japanese version](README.ja.md)
+[日本語版はこちら / Japanese version](README.md)
 
 ## Key Features
 
@@ -129,53 +129,24 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json` and paste
 
 Restart Claude Desktop after editing.
 
-### Build from source (Alternative)
+### Build from source (alternative)
+
+If Homebrew is unavailable (e.g. a restricted environment), build and register manually:
 
 ```bash
-# Clone the repository
 git clone https://github.com/BlueEventHorizon/Swift-Selena.git
 cd Swift-Selena
-
-# Build (release mode for production)
-make build-release
-
-# Or using swift directly:
-# swift build -c release -Xswiftc -Osize
+swift build -c release -Xswiftc -Osize
+# Artifact: .build/release/Swift-Selena
 ```
 
-The build artifact is generated at `.build/release/Swift-Selena`.
-
-### Available Make Commands
+Register the built binary with Claude Code:
 
 ```bash
-make help  # Show all available commands
+claude mcp add -s user swift-selena -- "$(pwd)/.build/release/Swift-Selena"
 ```
 
-#### Build
-
-| Command | Description |
-|---------|-------------|
-| `make build` | Build debug version |
-| `make build-release` | Build release version |
-| `make clean` | Clean build artifacts |
-
-#### MCP Helpers
-
-| Command | Target | Description |
-|---------|--------|-------------|
-| `make connect_gemini` | Claude Code | Connect gemini-cli MCP server |
-| `make disconnect_gemini` | Claude Code | Disconnect gemini-cli MCP server |
-
-#### Register / Unregister
-
-| Command | Target | Description |
-|---------|--------|-------------|
-| `make register-release` | Claude Code | Register RELEASE version (prompts for project path) |
-| `make unregister-release` | Claude Code | Unregister RELEASE version (prompts for project path) |
-| `make register-debug` | Claude Code | Build & register DEBUG version to Swift-Selena project |
-| `make unregister-debug` | Claude Code | Unregister DEBUG version from Swift-Selena project |
-| `make register-desktop` | Claude Desktop | Register to Claude Desktop |
-| `make unregister-desktop` | Claude Desktop | Unregister from Claude Desktop |
+> For all `make` commands, local development registration, and the release procedure, see **[CONTRIBUTING.md](CONTRIBUTING.md)**.
 
 ## Debugging & Logging
 
@@ -208,91 +179,6 @@ tail -f ~/.swift-selena/logs/server.log
 ```
 
 **Tip:** Keep `tail -f` running in a separate terminal while using Swift-Selena for real-time debugging.
-
-## Setup
-
-### Easy Setup (for source builds)
-
-Use make commands from the Swift-Selena project root:
-
-#### For Claude Desktop
-```bash
-make register-desktop
-```
-
-#### For Claude Code
-
-```bash
-# For production use (register to target project)
-make register-release
-# → Prompts: Enter the target project path
-
-# For development/testing (register to Swift-Selena project itself)
-make register-debug
-```
-
-#### Unregister
-
-```bash
-# Unregister from Claude Desktop
-make unregister-desktop
-
-# Unregister from target project
-make unregister-release
-# → Prompts: Enter the target project path (leave blank for current directory)
-
-# Unregister debug version from this project
-make unregister-debug
-```
-
-### Manual Setup
-
-If you prefer manual configuration:
-
-#### Claude Desktop Setup
-
-1. Open the config file (create if it doesn't exist):
-```bash
-open ~/Library/Application\ Support/Claude/claude_desktop_config.json
-```
-
-2. Add the following content:
-```json
-{
-  "mcpServers": {
-    "swift-selena": {
-      "command": "/path/to/Swift-Selena/.build/release/Swift-Selena",
-      "env": {
-        "MCP_CLIENT_ID": "claude-desktop"
-      }
-    }
-  },
-  "isUsingBuiltInNodeForMcp": true
-}
-```
-
-**Important**: Replace `/path/to/Swift-Selena` with the actual path.
-
-3. Restart Claude Desktop
-
-#### Claude Code Manual Setup
-
-In your target project directory:
-
-```bash
-cd /path/to/your/project
-claude mcp add swift-selena -- /path/to/Swift-Selena/.build/release/Swift-Selena
-```
-
-This creates a local configuration for that project only.
-
-**To use globally** (all projects):
-```bash
-cd ~
-claude mcp add -s user swift-selena -- /path/to/Swift-Selena/.build/release/Swift-Selena
-```
-
-Refer to [Claude Code documentation](https://docs.claude.com/claude-code) for more MCP server configuration options.
 
 ## Usage
 
@@ -413,18 +299,15 @@ Analysis cache is stored in the following directory:
 
 ### MCP server won't start
 
+Check that the binary runs and prints its startup banner:
+
 ```bash
-# Verify debug build
-swift build
-
-# Or verify release build
-swift build -c release -Xswiftc -Osize
-
-# Test release executable
-.build/release/Swift-Selena
-# "Starting Swift MCP Server..." should appear
-# Press Ctrl+C to exit
+# Homebrew install
+swift-selena
+# "Starting Swift MCP Server..." should appear; press Ctrl+C to exit
 ```
+
+If you built from source, run `.build/release/Swift-Selena` instead (see [CONTRIBUTING.md](CONTRIBUTING.md)).
 
 ### Tools not found
 
@@ -454,7 +337,7 @@ By default, Swift-Selena uses **Meta Tool Mode** (v0.6.3+). If you prefer to hav
 {
   "mcpServers": {
     "swift-selena": {
-      "command": "/path/to/Swift-Selena/.build/release/Swift-Selena",
+      "command": "/opt/homebrew/bin/swift-selena",
       "env": {
         "MCP_CLIENT_ID": "claude-desktop",
         "SWIFT_SELENA_LEGACY": "1"
@@ -466,7 +349,7 @@ By default, Swift-Selena uses **Meta Tool Mode** (v0.6.3+). If you prefer to hav
 
 #### Claude Code
 ```bash
-claude mcp add swift-selena -e SWIFT_SELENA_LEGACY=1 -- /path/to/Swift-Selena/.build/release/Swift-Selena
+claude mcp add swift-selena -e SWIFT_SELENA_LEGACY=1 -- swift-selena
 ```
 
 In legacy mode, the following 12 tools are exposed directly:


### PR DESCRIPTION
## 概要

- Homebrew が推奨インストール導線になったため、README から開発者向けの make / ソースビルド手順を整理し、CONTRIBUTING に集約してスリム化。

## 背景

- README に「Homebrew 登録」「make register-* 登録」「手動 JSON 登録」が分散し、登録方法が3重複していた。
- エンドユーザーには make ビルドは不要（Homebrew で完結）だが、開発者には必須。対象別に分離する。

## やったこと

- **README.md（日）/ README_en.md（英）**:
  - Homebrew（推奨）+ 最小フォールバック（`git clone` + `swift build -c release` + 手動 register）のみ残す
  - Make コマンド表・「セットアップ」セクション（make register-* + 手動 JSON）を削除 → CONTRIBUTING リンクに置換
  - Troubleshooting・Legacy Mode の例を Homebrew バイナリ（PATH 上の `swift-selena`）に整合
- **CONTRIBUTING.md（英）/ CONTRIBUTING.ja.md（日）**:
  - 「Building from source」「Development setup（make コマンド表・register-debug・手動 JSON 登録）」を release 手順の前に新設
- **リンク不整合の修正**:
  - README_en.md が存在しない `README.ja.md` を参照 → `README.md`
  - README.md が自分自身を English version としてリンク → `README_en.md`
  - CONTRIBUTING の README リンクを言語一致（en→README_en.md / ja→README.md）に

## やらないこと（このプルリクエストのスコープ外とすること）

- `development.md` の新設（CONTRIBUTING に集約する方針のため作らない）
- Formula / version 関連の変更（別管理）

## 画面設計書 / デザイン仕様書 / API仕様書

該当なし（ドキュメントのみ）。

## レビュー観点

- README がエンドユーザー導線（Homebrew + 最小フォールバック）に絞れているか
- CONTRIBUTING に開発者向け（ビルド・make・登録・リリース）が過不足なく集約されているか
- 英日両版の対称性、CONTRIBUTING への相互リンクが言語一致で正しいか
- 純減 60 行（+211 / -271）

## レビューレベル

- ~~Lv0: まったく見ないでAcceptする~~
- Lv1: ぱっとみて違和感がないかチェックしてAcceptする
- ~~Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証してAcceptする~~
- ~~Lv3: 実際に環境で動作確認したうえでAcceptする~~

## 備考

ドキュメントのみの変更。ビルド・version 検証の影響なし。
